### PR TITLE
Make the evolve button only show when Manage Team is enabled

### DIFF
--- a/main.js
+++ b/main.js
@@ -135,7 +135,7 @@ const makeDomHandler = () => {
         const evolveButton = poke.canEvolve()
             ? `<button href="#"
             onclick="userInteractions.evolvePokemon('${index}')"
-            style="display:inline"
+            style="display: ${ deleteEnabled && 'inline' || 'none' };"
             >
             Evolve
             </button>` 


### PR DESCRIPTION
Hey, I just realized that a complete living pokedex would fill your screen with lots of unnecessary evolve buttons, so I made it disappear unless Manage Team is enabled. Unless you'd like it to be there always, then you can just close this PR 😉