### PR TITLE
Add generations 2-6, updating the format for dual-type and shiny support

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,5 +1,4 @@
 const POKEDEX = [
-//1G
    {
       "pokemon": [
          {
@@ -16,10 +15,10 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "65",
             "speed": "45",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Poison"
+            ]
          }
       ],
       "exp": [
@@ -28,8 +27,14 @@ const POKEDEX = [
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bulbasaur.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bulbasaur.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bulbasaur.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bulbasaur.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bulbasaur.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bulbasaur.gif"
+         }
       }
    },
    {
@@ -48,20 +53,26 @@ const POKEDEX = [
             "sp atk": "80",
             "sp def": "80",
             "speed": "60",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "141"
+            "base exp": "142"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ivysaur.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ivysaur.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ivysaur.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ivysaur.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ivysaur.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ivysaur.gif"
+         }
       }
    },
    {
@@ -80,20 +91,26 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "100",
             "speed": "80",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "208"
+            "base exp": "236"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/venusaur.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/venusaur.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/venusaur.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/venusaur.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/venusaur.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/venusaur.gif"
+         }
       }
    },
    {
@@ -112,20 +129,25 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "50",
             "speed": "65",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "65"
+            "base exp": "62"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/charmander.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/charmander.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/charmander.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/charmander.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/charmander.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/charmander.gif"
+         }
       }
    },
    {
@@ -144,10 +166,9 @@ const POKEDEX = [
             "sp atk": "80",
             "sp def": "65",
             "speed": "80",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire"
+            ]
          }
       ],
       "exp": [
@@ -156,8 +177,14 @@ const POKEDEX = [
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/charmeleon.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/charmeleon.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/charmeleon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/charmeleon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/charmeleon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/charmeleon.gif"
+         }
       }
    },
    {
@@ -176,20 +203,26 @@ const POKEDEX = [
             "sp atk": "109",
             "sp def": "85",
             "speed": "100",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "209"
+            "base exp": "240"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/charizard.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/charizard.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/charizard.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/charizard.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/charizard.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/charizard.gif"
+         }
       }
    },
    {
@@ -208,20 +241,25 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "64",
             "speed": "43",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "66"
+            "base exp": "63"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/squirtle.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/squirtle.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/squirtle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/squirtle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/squirtle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/squirtle.gif"
+         }
       }
    },
    {
@@ -240,20 +278,25 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "80",
             "speed": "58",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "143"
+            "base exp": "142"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wartortle.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wartortle.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wartortle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wartortle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/wartortle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/wartortle.gif"
+         }
       }
    },
    {
@@ -272,20 +315,25 @@ const POKEDEX = [
             "sp atk": "85",
             "sp def": "105",
             "speed": "78",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "210"
+            "base exp": "239"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/blastoise.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/blastoise.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/blastoise.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/blastoise.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/blastoise.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/blastoise.gif"
+         }
       }
    },
    {
@@ -304,20 +352,25 @@ const POKEDEX = [
             "sp atk": "20",
             "sp def": "20",
             "speed": "45",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "53"
+            "base exp": "39"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/caterpie.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/caterpie.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/caterpie.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/caterpie.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/caterpie.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/caterpie.gif"
+         }
       }
    },
    {
@@ -336,10 +389,9 @@ const POKEDEX = [
             "sp atk": "25",
             "sp def": "25",
             "speed": "30",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug"
+            ]
          }
       ],
       "exp": [
@@ -348,8 +400,14 @@ const POKEDEX = [
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/metapod.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/metapod.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/metapod.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/metapod.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/metapod.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/metapod.gif"
+         }
       }
    },
    {
@@ -368,20 +426,26 @@ const POKEDEX = [
             "sp atk": "90",
             "sp def": "80",
             "speed": "70",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "160"
+            "base exp": "178"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/butterfree.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/butterfree.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/butterfree.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/butterfree.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/butterfree.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/butterfree.gif"
+         }
       }
    },
    {
@@ -400,20 +464,26 @@ const POKEDEX = [
             "sp atk": "20",
             "sp def": "20",
             "speed": "50",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "52"
+            "base exp": "39"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/weedle.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/weedle.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/weedle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/weedle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/weedle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/weedle.gif"
+         }
       }
    },
    {
@@ -432,20 +502,26 @@ const POKEDEX = [
             "sp atk": "25",
             "sp def": "25",
             "speed": "35",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "71"
+            "base exp": "72"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kakuna.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kakuna.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kakuna.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kakuna.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kakuna.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kakuna.gif"
+         }
       }
    },
    {
@@ -464,20 +540,26 @@ const POKEDEX = [
             "sp atk": "45",
             "sp def": "80",
             "speed": "75",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "159"
+            "base exp": "178"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/beedrill.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/beedrill.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/beedrill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/beedrill.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/beedrill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/beedrill.gif"
+         }
       }
    },
    {
@@ -496,20 +578,26 @@ const POKEDEX = [
             "sp atk": "35",
             "sp def": "35",
             "speed": "56",
-            "types": {
-               "text": "Flying",
-               "href": "https://pokemondb.net/type/flying"
-            }
+            "types": [
+               "Normal",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "55"
+            "base exp": "50"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pidgey.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pidgey.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pidgey.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pidgey.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pidgey.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pidgey.gif"
+         }
       }
    },
    {
@@ -528,20 +616,26 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "50",
             "speed": "71",
-            "types": {
-               "text": "Flying",
-               "href": "https://pokemondb.net/type/flying"
-            }
+            "types": [
+               "Normal",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "113"
+            "base exp": "122"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pidgeotto.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pidgeotto.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pidgeotto.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pidgeotto.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pidgeotto.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pidgeotto.gif"
+         }
       }
    },
    {
@@ -560,20 +654,26 @@ const POKEDEX = [
             "sp atk": "70",
             "sp def": "70",
             "speed": "101",
-            "types": {
-               "text": "Flying",
-               "href": "https://pokemondb.net/type/flying"
-            }
+            "types": [
+               "Normal",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "172"
+            "base exp": "216"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pidgeot.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pidgeot.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pidgeot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pidgeot.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pidgeot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pidgeot.gif"
+         }
       }
    },
    {
@@ -592,20 +692,25 @@ const POKEDEX = [
             "sp atk": "25",
             "sp def": "35",
             "speed": "72",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "57"
+            "base exp": "51"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rattata.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rattata.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rattata.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rattata.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/rattata.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/rattata.gif"
+         }
       }
    },
    {
@@ -624,20 +729,25 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "70",
             "speed": "97",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "116"
+            "base exp": "145"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/raticate.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/raticate.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/raticate.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/raticate.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/raticate.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/raticate.gif"
+         }
       }
    },
    {
@@ -656,20 +766,26 @@ const POKEDEX = [
             "sp atk": "31",
             "sp def": "31",
             "speed": "70",
-            "types": {
-               "text": "Flying",
-               "href": "https://pokemondb.net/type/flying"
-            }
+            "types": [
+               "Normal",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "58"
+            "base exp": "52"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/spearow.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/spearow.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/spearow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/spearow.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/spearow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/spearow.gif"
+         }
       }
    },
    {
@@ -688,20 +804,26 @@ const POKEDEX = [
             "sp atk": "61",
             "sp def": "61",
             "speed": "100",
-            "types": {
-               "text": "Flying",
-               "href": "https://pokemondb.net/type/flying"
-            }
+            "types": [
+               "Normal",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "162"
+            "base exp": "155"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/fearow.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/fearow.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/fearow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/fearow.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/fearow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/fearow.gif"
+         }
       }
    },
    {
@@ -720,20 +842,25 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "54",
             "speed": "55",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "62"
+            "base exp": "58"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ekans.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ekans.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ekans.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ekans.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ekans.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ekans.gif"
+         }
       }
    },
    {
@@ -752,20 +879,25 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "79",
             "speed": "80",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "147"
+            "base exp": "153"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/arbok.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/arbok.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/arbok.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/arbok.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/arbok.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/arbok.gif"
+         }
       }
    },
    {
@@ -784,20 +916,25 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "50",
             "speed": "90",
-            "types": {
-               "text": "Electric",
-               "href": "https://pokemondb.net/type/electric"
-            }
+            "types": [
+               "Electric"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "82"
+            "base exp": "112"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pikachu.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pikachu.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pikachu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pikachu.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pikachu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pikachu.gif"
+         }
       }
    },
    {
@@ -816,20 +953,25 @@ const POKEDEX = [
             "sp atk": "90",
             "sp def": "80",
             "speed": "110",
-            "types": {
-               "text": "Electric",
-               "href": "https://pokemondb.net/type/electric"
-            }
+            "types": [
+               "Electric"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "122"
+            "base exp": "218"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/raichu.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/raichu.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/raichu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/raichu.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/raichu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/raichu.gif"
+         }
       }
    },
    {
@@ -848,20 +990,25 @@ const POKEDEX = [
             "sp atk": "20",
             "sp def": "30",
             "speed": "40",
-            "types": {
-               "text": "Ground",
-               "href": "https://pokemondb.net/type/ground"
-            }
+            "types": [
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "93"
+            "base exp": "60"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sandshrew.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sandshrew.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sandshrew.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sandshrew.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sandshrew.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sandshrew.gif"
+         }
       }
    },
    {
@@ -880,26 +1027,31 @@ const POKEDEX = [
             "sp atk": "45",
             "sp def": "55",
             "speed": "65",
-            "types": {
-               "text": "Ground",
-               "href": "https://pokemondb.net/type/ground"
-            }
+            "types": [
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "163"
+            "base exp": "158"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sandslash.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sandslash.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sandslash.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sandslash.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sandslash.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sandslash.gif"
+         }
       }
    },
    {
       "pokemon": [
          {
-            "Pokemon": "Nidoran f"
+            "Pokemon": "Nidoran-f"
          }
       ],
       "stats": [
@@ -912,20 +1064,25 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "40",
             "speed": "41",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "59"
+            "base exp": "55"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidoran-f.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidoran-f.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidoran-f.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidoran-f.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/nidoran-f.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/nidoran-f.gif"
+         }
       }
    },
    {
@@ -944,20 +1101,25 @@ const POKEDEX = [
             "sp atk": "55",
             "sp def": "55",
             "speed": "56",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "117"
+            "base exp": "128"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidorina.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidorina.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidorina.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidorina.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/nidorina.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/nidorina.gif"
+         }
       }
    },
    {
@@ -976,26 +1138,32 @@ const POKEDEX = [
             "sp atk": "75",
             "sp def": "85",
             "speed": "76",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison",
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "194"
+            "base exp": "227"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidoqueen.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidoqueen.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidoqueen.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidoqueen.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/nidoqueen.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/nidoqueen.gif"
+         }
       }
    },
    {
       "pokemon": [
          {
-            "Pokemon": "Nidoran m"
+            "Pokemon": "Nidoran-m"
          }
       ],
       "stats": [
@@ -1008,20 +1176,25 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "40",
             "speed": "50",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "60"
+            "base exp": "55"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidoran-m.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidoran-m.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidoran-m.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidoran-m.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/nidoran-m.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/nidoran-m.gif"
+         }
       }
    },
    {
@@ -1040,20 +1213,25 @@ const POKEDEX = [
             "sp atk": "55",
             "sp def": "55",
             "speed": "65",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "118"
+            "base exp": "128"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidorino.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidorino.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidorino.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidorino.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/nidorino.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/nidorino.gif"
+         }
       }
    },
    {
@@ -1072,20 +1250,26 @@ const POKEDEX = [
             "sp atk": "85",
             "sp def": "75",
             "speed": "85",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison",
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "195"
+            "base exp": "227"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidoking.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidoking.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nidoking.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nidoking.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/nidoking.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/nidoking.gif"
+         }
       }
    },
    {
@@ -1104,20 +1288,25 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "65",
             "speed": "35",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Fairy"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "68"
+            "base exp": "113"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/clefairy.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/clefairy.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/clefairy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/clefairy.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/clefairy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/clefairy.gif"
+         }
       }
    },
    {
@@ -1136,20 +1325,25 @@ const POKEDEX = [
             "sp atk": "95",
             "sp def": "90",
             "speed": "60",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Fairy"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "129"
+            "base exp": "217"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/clefable.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/clefable.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/clefable.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/clefable.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/clefable.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/clefable.gif"
+         }
       }
    },
    {
@@ -1168,20 +1362,25 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "65",
             "speed": "65",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "63"
+            "base exp": "60"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vulpix.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vulpix.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vulpix.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vulpix.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/vulpix.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/vulpix.gif"
+         }
       }
    },
    {
@@ -1200,20 +1399,25 @@ const POKEDEX = [
             "sp atk": "81",
             "sp def": "100",
             "speed": "100",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "178"
+            "base exp": "177"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ninetales.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ninetales.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ninetales.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ninetales.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ninetales.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ninetales.gif"
+         }
       }
    },
    {
@@ -1232,20 +1436,26 @@ const POKEDEX = [
             "sp atk": "45",
             "sp def": "25",
             "speed": "20",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal",
+               "Fairy"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "76"
+            "base exp": "95"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/jigglypuff.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/jigglypuff.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/jigglypuff.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/jigglypuff.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/jigglypuff.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/jigglypuff.gif"
+         }
       }
    },
    {
@@ -1264,20 +1474,26 @@ const POKEDEX = [
             "sp atk": "85",
             "sp def": "50",
             "speed": "45",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal",
+               "Fairy"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "109"
+            "base exp": "196"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wigglytuff.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wigglytuff.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wigglytuff.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wigglytuff.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/wigglytuff.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/wigglytuff.gif"
+         }
       }
    },
    {
@@ -1296,20 +1512,26 @@ const POKEDEX = [
             "sp atk": "30",
             "sp def": "40",
             "speed": "55",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "54"
+            "base exp": "49"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zubat.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zubat.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zubat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zubat.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/zubat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/zubat.gif"
+         }
       }
    },
    {
@@ -1328,20 +1550,26 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "75",
             "speed": "90",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "171"
+            "base exp": "159"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/golbat.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/golbat.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/golbat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/golbat.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/golbat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/golbat.gif"
+         }
       }
    },
    {
@@ -1360,20 +1588,26 @@ const POKEDEX = [
             "sp atk": "75",
             "sp def": "65",
             "speed": "30",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "78"
+            "base exp": "64"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/oddish.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/oddish.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/oddish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/oddish.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/oddish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/oddish.gif"
+         }
       }
    },
    {
@@ -1392,20 +1626,26 @@ const POKEDEX = [
             "sp atk": "85",
             "sp def": "75",
             "speed": "40",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "132"
+            "base exp": "138"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gloom.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gloom.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gloom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gloom.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gloom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gloom.gif"
+         }
       }
    },
    {
@@ -1424,20 +1664,26 @@ const POKEDEX = [
             "sp atk": "110",
             "sp def": "90",
             "speed": "50",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "184"
+            "base exp": "221"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vileplume.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vileplume.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vileplume.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vileplume.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/vileplume.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/vileplume.gif"
+         }
       }
    },
    {
@@ -1456,20 +1702,26 @@ const POKEDEX = [
             "sp atk": "45",
             "sp def": "55",
             "speed": "25",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug",
+               "Grass"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "70"
+            "base exp": "57"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/paras.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/paras.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/paras.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/paras.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/paras.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/paras.gif"
+         }
       }
    },
    {
@@ -1488,20 +1740,26 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "80",
             "speed": "30",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug",
+               "Grass"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "128"
+            "base exp": "142"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/parasect.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/parasect.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/parasect.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/parasect.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/parasect.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/parasect.gif"
+         }
       }
    },
    {
@@ -1520,20 +1778,26 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "55",
             "speed": "45",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "75"
+            "base exp": "61"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/venonat.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/venonat.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/venonat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/venonat.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/venonat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/venonat.gif"
+         }
       }
    },
    {
@@ -1552,20 +1816,26 @@ const POKEDEX = [
             "sp atk": "90",
             "sp def": "75",
             "speed": "90",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "138"
+            "base exp": "158"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/venomoth.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/venomoth.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/venomoth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/venomoth.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/venomoth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/venomoth.gif"
+         }
       }
    },
    {
@@ -1584,20 +1854,25 @@ const POKEDEX = [
             "sp atk": "35",
             "sp def": "45",
             "speed": "95",
-            "types": {
-               "text": "Ground",
-               "href": "https://pokemondb.net/type/ground"
-            }
+            "types": [
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "81"
+            "base exp": "53"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/diglett.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/diglett.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/diglett.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/diglett.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/diglett.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/diglett.gif"
+         }
       }
    },
    {
@@ -1616,20 +1891,25 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "70",
             "speed": "120",
-            "types": {
-               "text": "Ground",
-               "href": "https://pokemondb.net/type/ground"
-            }
+            "types": [
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "153"
+            "base exp": "142"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dugtrio.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dugtrio.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dugtrio.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dugtrio.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dugtrio.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dugtrio.gif"
+         }
       }
    },
    {
@@ -1648,20 +1928,25 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "40",
             "speed": "90",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "69"
+            "base exp": "58"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/meowth.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/meowth.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/meowth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/meowth.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/meowth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/meowth.gif"
+         }
       }
    },
    {
@@ -1680,20 +1965,25 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "65",
             "speed": "115",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "148"
+            "base exp": "154"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/persian.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/persian.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/persian.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/persian.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/persian.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/persian.gif"
+         }
       }
    },
    {
@@ -1712,20 +2002,25 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "50",
             "speed": "55",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "80"
+            "base exp": "64"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/psyduck.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/psyduck.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/psyduck.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/psyduck.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/psyduck.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/psyduck.gif"
+         }
       }
    },
    {
@@ -1744,20 +2039,25 @@ const POKEDEX = [
             "sp atk": "95",
             "sp def": "80",
             "speed": "85",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "174"
+            "base exp": "175"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/golduck.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/golduck.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/golduck.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/golduck.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/golduck.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/golduck.gif"
+         }
       }
    },
    {
@@ -1776,20 +2076,25 @@ const POKEDEX = [
             "sp atk": "35",
             "sp def": "45",
             "speed": "70",
-            "types": {
-               "text": "Fighting",
-               "href": "https://pokemondb.net/type/fighting"
-            }
+            "types": [
+               "Fighting"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "74"
+            "base exp": "61"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mankey.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mankey.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mankey.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mankey.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mankey.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mankey.gif"
+         }
       }
    },
    {
@@ -1808,20 +2113,25 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "70",
             "speed": "95",
-            "types": {
-               "text": "Fighting",
-               "href": "https://pokemondb.net/type/fighting"
-            }
+            "types": [
+               "Fighting"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "149"
+            "base exp": "159"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/primeape.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/primeape.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/primeape.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/primeape.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/primeape.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/primeape.gif"
+         }
       }
    },
    {
@@ -1840,20 +2150,25 @@ const POKEDEX = [
             "sp atk": "70",
             "sp def": "50",
             "speed": "60",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "91"
+            "base exp": "70"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/growlithe.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/growlithe.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/growlithe.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/growlithe.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/growlithe.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/growlithe.gif"
+         }
       }
    },
    {
@@ -1872,20 +2187,25 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "80",
             "speed": "95",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "213"
+            "base exp": "194"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/arcanine.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/arcanine.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/arcanine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/arcanine.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/arcanine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/arcanine.gif"
+         }
       }
    },
    {
@@ -1904,20 +2224,25 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "40",
             "speed": "90",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "77"
+            "base exp": "60"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/poliwag.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/poliwag.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/poliwag.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/poliwag.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/poliwag.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/poliwag.gif"
+         }
       }
    },
    {
@@ -1936,20 +2261,25 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "50",
             "speed": "90",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "131"
+            "base exp": "135"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/poliwhirl.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/poliwhirl.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/poliwhirl.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/poliwhirl.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/poliwhirl.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/poliwhirl.gif"
+         }
       }
    },
    {
@@ -1968,20 +2298,26 @@ const POKEDEX = [
             "sp atk": "70",
             "sp def": "90",
             "speed": "70",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Fighting"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "185"
+            "base exp": "230"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/poliwrath.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/poliwrath.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/poliwrath.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/poliwrath.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/poliwrath.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/poliwrath.gif"
+         }
       }
    },
    {
@@ -2000,20 +2336,25 @@ const POKEDEX = [
             "sp atk": "105",
             "sp def": "55",
             "speed": "90",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "75"
+            "base exp": "62"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/abra.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/abra.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/abra.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/abra.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/abra.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/abra.gif"
+         }
       }
    },
    {
@@ -2032,20 +2373,25 @@ const POKEDEX = [
             "sp atk": "120",
             "sp def": "70",
             "speed": "105",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "145"
+            "base exp": "140"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kadabra.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kadabra.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kadabra.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kadabra.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kadabra.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kadabra.gif"
+         }
       }
    },
    {
@@ -2064,20 +2410,25 @@ const POKEDEX = [
             "sp atk": "135",
             "sp def": "95",
             "speed": "120",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "186"
+            "base exp": "225"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/alakazam.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/alakazam.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/alakazam.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/alakazam.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/alakazam.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/alakazam.gif"
+         }
       }
    },
    {
@@ -2096,20 +2447,25 @@ const POKEDEX = [
             "sp atk": "35",
             "sp def": "35",
             "speed": "35",
-            "types": {
-               "text": "Fighting",
-               "href": "https://pokemondb.net/type/fighting"
-            }
+            "types": [
+               "Fighting"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "75"
+            "base exp": "61"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/machop.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/machop.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/machop.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/machop.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/machop.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/machop.gif"
+         }
       }
    },
    {
@@ -2128,20 +2484,25 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "60",
             "speed": "45",
-            "types": {
-               "text": "Fighting",
-               "href": "https://pokemondb.net/type/fighting"
-            }
+            "types": [
+               "Fighting"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "146"
+            "base exp": "142"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/machoke.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/machoke.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/machoke.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/machoke.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/machoke.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/machoke.gif"
+         }
       }
    },
    {
@@ -2160,20 +2521,25 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "85",
             "speed": "55",
-            "types": {
-               "text": "Fighting",
-               "href": "https://pokemondb.net/type/fighting"
-            }
+            "types": [
+               "Fighting"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "193"
+            "base exp": "227"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/machamp.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/machamp.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/machamp.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/machamp.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/machamp.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/machamp.gif"
+         }
       }
    },
    {
@@ -2192,20 +2558,26 @@ const POKEDEX = [
             "sp atk": "70",
             "sp def": "30",
             "speed": "40",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "84"
+            "base exp": "60"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bellsprout.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bellsprout.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bellsprout.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bellsprout.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bellsprout.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bellsprout.gif"
+         }
       }
    },
    {
@@ -2224,20 +2596,26 @@ const POKEDEX = [
             "sp atk": "85",
             "sp def": "45",
             "speed": "55",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "151"
+            "base exp": "137"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/weepinbell.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/weepinbell.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/weepinbell.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/weepinbell.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/weepinbell.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/weepinbell.gif"
+         }
       }
    },
    {
@@ -2256,20 +2634,26 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "70",
             "speed": "70",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "191"
+            "base exp": "221"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/victreebel.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/victreebel.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/victreebel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/victreebel.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/victreebel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/victreebel.gif"
+         }
       }
    },
    {
@@ -2288,20 +2672,26 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "100",
             "speed": "70",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "105"
+            "base exp": "67"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tentacool.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tentacool.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tentacool.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tentacool.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tentacool.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tentacool.gif"
+         }
       }
    },
    {
@@ -2320,20 +2710,26 @@ const POKEDEX = [
             "sp atk": "80",
             "sp def": "120",
             "speed": "100",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "205"
+            "base exp": "180"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tentacruel.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tentacruel.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tentacruel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tentacruel.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tentacruel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tentacruel.gif"
+         }
       }
    },
    {
@@ -2352,20 +2748,26 @@ const POKEDEX = [
             "sp atk": "30",
             "sp def": "30",
             "speed": "20",
-            "types": {
-               "text": "Rock",
-               "href": "https://pokemondb.net/type/rock"
-            }
+            "types": [
+               "Rock",
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "73"
+            "base exp": "60"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/geodude.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/geodude.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/geodude.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/geodude.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/geodude.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/geodude.gif"
+         }
       }
    },
    {
@@ -2384,20 +2786,26 @@ const POKEDEX = [
             "sp atk": "45",
             "sp def": "45",
             "speed": "35",
-            "types": {
-               "text": "Rock",
-               "href": "https://pokemondb.net/type/rock"
-            }
+            "types": [
+               "Rock",
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "134"
+            "base exp": "137"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/graveler.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/graveler.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/graveler.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/graveler.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/graveler.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/graveler.gif"
+         }
       }
    },
    {
@@ -2416,20 +2824,26 @@ const POKEDEX = [
             "sp atk": "55",
             "sp def": "65",
             "speed": "45",
-            "types": {
-               "text": "Rock",
-               "href": "https://pokemondb.net/type/rock"
-            }
+            "types": [
+               "Rock",
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "177"
+            "base exp": "223"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/golem.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/golem.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/golem.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/golem.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/golem.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/golem.gif"
+         }
       }
    },
    {
@@ -2448,20 +2862,25 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "65",
             "speed": "90",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "152"
+            "base exp": "82"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ponyta.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ponyta.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ponyta.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ponyta.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ponyta.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ponyta.gif"
+         }
       }
    },
    {
@@ -2480,20 +2899,25 @@ const POKEDEX = [
             "sp atk": "80",
             "sp def": "80",
             "speed": "105",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "192"
+            "base exp": "175"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rapidash.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rapidash.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rapidash.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rapidash.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/rapidash.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/rapidash.gif"
+         }
       }
    },
    {
@@ -2512,20 +2936,26 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "40",
             "speed": "15",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "99"
+            "base exp": "63"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/slowpoke.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/slowpoke.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/slowpoke.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/slowpoke.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/slowpoke.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/slowpoke.gif"
+         }
       }
    },
    {
@@ -2544,20 +2974,26 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "80",
             "speed": "30",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "164"
+            "base exp": "172"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/slowbro.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/slowbro.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/slowbro.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/slowbro.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/slowbro.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/slowbro.gif"
+         }
       }
    },
    {
@@ -2576,20 +3012,26 @@ const POKEDEX = [
             "sp atk": "95",
             "sp def": "55",
             "speed": "45",
-            "types": {
-               "text": "Electric",
-               "href": "https://pokemondb.net/type/electric"
-            }
+            "types": [
+               "Electric",
+               "Steel"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "89"
+            "base exp": "65"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magnemite.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magnemite.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magnemite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magnemite.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/magnemite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/magnemite.gif"
+         }
       }
    },
    {
@@ -2608,20 +3050,26 @@ const POKEDEX = [
             "sp atk": "120",
             "sp def": "70",
             "speed": "70",
-            "types": {
-               "text": "Electric",
-               "href": "https://pokemondb.net/type/electric"
-            }
+            "types": [
+               "Electric",
+               "Steel"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "161"
+            "base exp": "163"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magneton.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magneton.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magneton.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magneton.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/magneton.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/magneton.gif"
+         }
       }
    },
    {
@@ -2640,20 +3088,26 @@ const POKEDEX = [
             "sp atk": "58",
             "sp def": "62",
             "speed": "60",
-            "types": {
-               "text": "Flying",
-               "href": "https://pokemondb.net/type/flying"
-            }
+            "types": [
+               "Normal",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "94"
+            "base exp": "123"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/farfetchd.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/farfetchd.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/farfetchd.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/farfetchd.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/farfetchd.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/farfetchd.gif"
+         }
       }
    },
    {
@@ -2672,20 +3126,26 @@ const POKEDEX = [
             "sp atk": "35",
             "sp def": "35",
             "speed": "75",
-            "types": {
-               "text": "Flying",
-               "href": "https://pokemondb.net/type/flying"
-            }
+            "types": [
+               "Normal",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "96"
+            "base exp": "62"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/doduo.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/doduo.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/doduo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/doduo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/doduo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/doduo.gif"
+         }
       }
    },
    {
@@ -2704,20 +3164,26 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "60",
             "speed": "100",
-            "types": {
-               "text": "Flying",
-               "href": "https://pokemondb.net/type/flying"
-            }
+            "types": [
+               "Normal",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "158"
+            "base exp": "161"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dodrio.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dodrio.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dodrio.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dodrio.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dodrio.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dodrio.gif"
+         }
       }
    },
    {
@@ -2736,20 +3202,25 @@ const POKEDEX = [
             "sp atk": "45",
             "sp def": "70",
             "speed": "45",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "100"
+            "base exp": "65"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/seel.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/seel.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/seel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/seel.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/seel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/seel.gif"
+         }
       }
    },
    {
@@ -2768,20 +3239,26 @@ const POKEDEX = [
             "sp atk": "70",
             "sp def": "95",
             "speed": "70",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Ice"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "176"
+            "base exp": "166"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dewgong.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dewgong.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dewgong.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dewgong.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dewgong.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dewgong.gif"
+         }
       }
    },
    {
@@ -2800,20 +3277,25 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "50",
             "speed": "25",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "90"
+            "base exp": "65"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/grimer.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/grimer.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/grimer.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/grimer.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/grimer.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/grimer.gif"
+         }
       }
    },
    {
@@ -2832,20 +3314,25 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "100",
             "speed": "50",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "157"
+            "base exp": "175"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/muk.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/muk.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/muk.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/muk.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/muk.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/muk.gif"
+         }
       }
    },
    {
@@ -2864,20 +3351,25 @@ const POKEDEX = [
             "sp atk": "45",
             "sp def": "25",
             "speed": "40",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "97"
+            "base exp": "61"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shellder.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shellder.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shellder.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shellder.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shellder.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shellder.gif"
+         }
       }
    },
    {
@@ -2896,20 +3388,26 @@ const POKEDEX = [
             "sp atk": "85",
             "sp def": "45",
             "speed": "70",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Ice"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "203"
+            "base exp": "184"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cloyster.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cloyster.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cloyster.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cloyster.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cloyster.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cloyster.gif"
+         }
       }
    },
    {
@@ -2928,20 +3426,26 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "35",
             "speed": "80",
-            "types": {
-               "text": "Ghost",
-               "href": "https://pokemondb.net/type/ghost"
-            }
+            "types": [
+               "Ghost",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "95"
+            "base exp": "62"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gastly.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gastly.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gastly.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gastly.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gastly.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gastly.gif"
+         }
       }
    },
    {
@@ -2960,20 +3464,26 @@ const POKEDEX = [
             "sp atk": "115",
             "sp def": "55",
             "speed": "95",
-            "types": {
-               "text": "Ghost",
-               "href": "https://pokemondb.net/type/ghost"
-            }
+            "types": [
+               "Ghost",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "126"
+            "base exp": "142"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/haunter.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/haunter.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/haunter.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/haunter.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/haunter.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/haunter.gif"
+         }
       }
    },
    {
@@ -2992,20 +3502,26 @@ const POKEDEX = [
             "sp atk": "130",
             "sp def": "75",
             "speed": "110",
-            "types": {
-               "text": "Ghost",
-               "href": "https://pokemondb.net/type/ghost"
-            }
+            "types": [
+               "Ghost",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "190"
+            "base exp": "225"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gengar.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gengar.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gengar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gengar.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gengar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gengar.gif"
+         }
       }
    },
    {
@@ -3024,20 +3540,26 @@ const POKEDEX = [
             "sp atk": "30",
             "sp def": "45",
             "speed": "70",
-            "types": {
-               "text": "Rock",
-               "href": "https://pokemondb.net/type/rock"
-            }
+            "types": [
+               "Rock",
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "108"
+            "base exp": "77"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/onix.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/onix.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/onix.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/onix.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/onix.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/onix.gif"
+         }
       }
    },
    {
@@ -3056,20 +3578,25 @@ const POKEDEX = [
             "sp atk": "43",
             "sp def": "90",
             "speed": "42",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "102"
+            "base exp": "66"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/drowzee.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/drowzee.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/drowzee.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/drowzee.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/drowzee.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/drowzee.gif"
+         }
       }
    },
    {
@@ -3088,20 +3615,25 @@ const POKEDEX = [
             "sp atk": "73",
             "sp def": "115",
             "speed": "67",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "165"
+            "base exp": "169"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hypno.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hypno.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hypno.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hypno.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/hypno.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/hypno.gif"
+         }
       }
    },
    {
@@ -3120,20 +3652,25 @@ const POKEDEX = [
             "sp atk": "25",
             "sp def": "25",
             "speed": "50",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "115"
+            "base exp": "65"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/krabby.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/krabby.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/krabby.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/krabby.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/krabby.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/krabby.gif"
+         }
       }
    },
    {
@@ -3152,20 +3689,25 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "50",
             "speed": "75",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "206"
+            "base exp": "166"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kingler.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kingler.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kingler.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kingler.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kingler.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kingler.gif"
+         }
       }
    },
    {
@@ -3184,20 +3726,25 @@ const POKEDEX = [
             "sp atk": "55",
             "sp def": "55",
             "speed": "100",
-            "types": {
-               "text": "Electric",
-               "href": "https://pokemondb.net/type/electric"
-            }
+            "types": [
+               "Electric"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "103"
+            "base exp": "66"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/voltorb.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/voltorb.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/voltorb.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/voltorb.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/voltorb.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/voltorb.gif"
+         }
       }
    },
    {
@@ -3216,20 +3763,25 @@ const POKEDEX = [
             "sp atk": "80",
             "sp def": "80",
             "speed": "140",
-            "types": {
-               "text": "Electric",
-               "href": "https://pokemondb.net/type/electric"
-            }
+            "types": [
+               "Electric"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "150"
+            "base exp": "168"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/electrode.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/electrode.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/electrode.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/electrode.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/electrode.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/electrode.gif"
+         }
       }
    },
    {
@@ -3248,20 +3800,26 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "45",
             "speed": "40",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "98"
+            "base exp": "65"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/exeggcute.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/exeggcute.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/exeggcute.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/exeggcute.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/exeggcute.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/exeggcute.gif"
+         }
       }
    },
    {
@@ -3280,20 +3838,26 @@ const POKEDEX = [
             "sp atk": "125",
             "sp def": "65",
             "speed": "55",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "212"
+            "base exp": "182"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/exeggutor.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/exeggutor.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/exeggutor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/exeggutor.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/exeggutor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/exeggutor.gif"
+         }
       }
    },
    {
@@ -3312,20 +3876,25 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "50",
             "speed": "35",
-            "types": {
-               "text": "Ground",
-               "href": "https://pokemondb.net/type/ground"
-            }
+            "types": [
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "87"
+            "base exp": "64"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cubone.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cubone.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cubone.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cubone.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cubone.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cubone.gif"
+         }
       }
    },
    {
@@ -3344,20 +3913,25 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "80",
             "speed": "45",
-            "types": {
-               "text": "Ground",
-               "href": "https://pokemondb.net/type/ground"
-            }
+            "types": [
+               "Ground"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "124"
+            "base exp": "149"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/marowak.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/marowak.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/marowak.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/marowak.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/marowak.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/marowak.gif"
+         }
       }
    },
    {
@@ -3376,20 +3950,25 @@ const POKEDEX = [
             "sp atk": "35",
             "sp def": "110",
             "speed": "87",
-            "types": {
-               "text": "Fighting",
-               "href": "https://pokemondb.net/type/fighting"
-            }
+            "types": [
+               "Fighting"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "139"
+            "base exp": "159"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hitmonlee.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hitmonlee.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hitmonlee.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hitmonlee.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/hitmonlee.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/hitmonlee.gif"
+         }
       }
    },
    {
@@ -3408,20 +3987,25 @@ const POKEDEX = [
             "sp atk": "35",
             "sp def": "110",
             "speed": "76",
-            "types": {
-               "text": "Fighting",
-               "href": "https://pokemondb.net/type/fighting"
-            }
+            "types": [
+               "Fighting"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "140"
+            "base exp": "159"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hitmonchan.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hitmonchan.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hitmonchan.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hitmonchan.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/hitmonchan.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/hitmonchan.gif"
+         }
       }
    },
    {
@@ -3440,20 +4024,25 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "75",
             "speed": "30",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "127"
+            "base exp": "77"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lickitung.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lickitung.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lickitung.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lickitung.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lickitung.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lickitung.gif"
+         }
       }
    },
    {
@@ -3472,20 +4061,25 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "45",
             "speed": "35",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "114"
+            "base exp": "68"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/koffing.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/koffing.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/koffing.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/koffing.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/koffing.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/koffing.gif"
+         }
       }
    },
    {
@@ -3504,20 +4098,25 @@ const POKEDEX = [
             "sp atk": "85",
             "sp def": "70",
             "speed": "60",
-            "types": {
-               "text": "Poison",
-               "href": "https://pokemondb.net/type/poison"
-            }
+            "types": [
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "173"
+            "base exp": "172"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/weezing.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/weezing.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/weezing.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/weezing.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/weezing.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/weezing.gif"
+         }
       }
    },
    {
@@ -3536,20 +4135,26 @@ const POKEDEX = [
             "sp atk": "30",
             "sp def": "30",
             "speed": "25",
-            "types": {
-               "text": "Ground",
-               "href": "https://pokemondb.net/type/ground"
-            }
+            "types": [
+               "Ground",
+               "Rock"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "135"
+            "base exp": "69"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rhyhorn.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rhyhorn.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rhyhorn.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rhyhorn.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/rhyhorn.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/rhyhorn.gif"
+         }
       }
    },
    {
@@ -3568,20 +4173,26 @@ const POKEDEX = [
             "sp atk": "45",
             "sp def": "45",
             "speed": "40",
-            "types": {
-               "text": "Ground",
-               "href": "https://pokemondb.net/type/ground"
-            }
+            "types": [
+               "Ground",
+               "Rock"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "204"
+            "base exp": "170"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rhydon.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rhydon.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rhydon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rhydon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/rhydon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/rhydon.gif"
+         }
       }
    },
    {
@@ -3600,20 +4211,25 @@ const POKEDEX = [
             "sp atk": "35",
             "sp def": "105",
             "speed": "50",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "255"
+            "base exp": "395"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/chansey.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/chansey.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/chansey.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/chansey.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/chansey.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/chansey.gif"
+         }
       }
    },
    {
@@ -3632,20 +4248,25 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "40",
             "speed": "60",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "166"
+            "base exp": "87"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tangela.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tangela.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tangela.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tangela.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tangela.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tangela.gif"
+         }
       }
    },
    {
@@ -3664,20 +4285,25 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "80",
             "speed": "90",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "175"
+            "base exp": "172"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kangaskhan.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kangaskhan.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kangaskhan.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kangaskhan.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kangaskhan.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kangaskhan.gif"
+         }
       }
    },
    {
@@ -3696,20 +4322,25 @@ const POKEDEX = [
             "sp atk": "70",
             "sp def": "25",
             "speed": "60",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "83"
+            "base exp": "59"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/horsea.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/horsea.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/horsea.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/horsea.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/horsea.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/horsea.gif"
+         }
       }
    },
    {
@@ -3728,20 +4359,25 @@ const POKEDEX = [
             "sp atk": "95",
             "sp def": "45",
             "speed": "85",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "155"
+            "base exp": "154"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/seadra.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/seadra.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/seadra.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/seadra.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/seadra.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/seadra.gif"
+         }
       }
    },
    {
@@ -3760,20 +4396,25 @@ const POKEDEX = [
             "sp atk": "35",
             "sp def": "50",
             "speed": "63",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "111"
+            "base exp": "64"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/goldeen.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/goldeen.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/goldeen.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/goldeen.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/goldeen.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/goldeen.gif"
+         }
       }
    },
    {
@@ -3792,20 +4433,25 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "80",
             "speed": "68",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "170"
+            "base exp": "158"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/seaking.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/seaking.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/seaking.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/seaking.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/seaking.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/seaking.gif"
+         }
       }
    },
    {
@@ -3824,20 +4470,25 @@ const POKEDEX = [
             "sp atk": "70",
             "sp def": "55",
             "speed": "85",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "106"
+            "base exp": "68"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/staryu.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/staryu.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/staryu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/staryu.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/staryu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/staryu.gif"
+         }
       }
    },
    {
@@ -3856,26 +4507,32 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "85",
             "speed": "115",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "207"
+            "base exp": "182"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/starmie.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/starmie.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/starmie.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/starmie.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/starmie.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/starmie.gif"
+         }
       }
    },
    {
       "pokemon": [
          {
-            "Pokemon": "Mr. Mime"
+            "Pokemon": "Mr-mime"
          }
       ],
       "stats": [
@@ -3888,20 +4545,26 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "120",
             "speed": "90",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic",
+               "Fairy"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "136"
+            "base exp": "161"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mr-mime.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mr-mime.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mr-mime.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mr-mime.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mr-mime.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mr-mime.gif"
+         }
       }
    },
    {
@@ -3920,20 +4583,26 @@ const POKEDEX = [
             "sp atk": "55",
             "sp def": "80",
             "speed": "105",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "187"
+            "base exp": "100"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/scyther.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/scyther.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/scyther.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/scyther.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/scyther.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/scyther.gif"
+         }
       }
    },
    {
@@ -3952,20 +4621,26 @@ const POKEDEX = [
             "sp atk": "115",
             "sp def": "95",
             "speed": "95",
-            "types": {
-               "text": "Ice",
-               "href": "https://pokemondb.net/type/ice"
-            }
+            "types": [
+               "Ice",
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "137"
+            "base exp": "159"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/jynx.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/jynx.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/jynx.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/jynx.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/jynx.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/jynx.gif"
+         }
       }
    },
    {
@@ -3984,20 +4659,25 @@ const POKEDEX = [
             "sp atk": "95",
             "sp def": "85",
             "speed": "105",
-            "types": {
-               "text": "Electric",
-               "href": "https://pokemondb.net/type/electric"
-            }
+            "types": [
+               "Electric"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "156"
+            "base exp": "172"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/electabuzz.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/electabuzz.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/electabuzz.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/electabuzz.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/electabuzz.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/electabuzz.gif"
+         }
       }
    },
    {
@@ -4016,20 +4696,25 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "85",
             "speed": "93",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "167"
+            "base exp": "173"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magmar.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magmar.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magmar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magmar.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/magmar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/magmar.gif"
+         }
       }
    },
    {
@@ -4048,20 +4733,25 @@ const POKEDEX = [
             "sp atk": "55",
             "sp def": "70",
             "speed": "85",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "200"
+            "base exp": "175"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pinsir.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pinsir.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pinsir.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pinsir.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pinsir.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pinsir.gif"
+         }
       }
    },
    {
@@ -4080,20 +4770,25 @@ const POKEDEX = [
             "sp atk": "40",
             "sp def": "70",
             "speed": "110",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "211"
+            "base exp": "172"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tauros.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tauros.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tauros.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tauros.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tauros.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tauros.gif"
+         }
       }
    },
    {
@@ -4112,20 +4807,25 @@ const POKEDEX = [
             "sp atk": "15",
             "sp def": "20",
             "speed": "80",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "20"
+            "base exp": "40"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magikarp.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magikarp.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magikarp.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magikarp.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/magikarp.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/magikarp.gif"
+         }
       }
    },
    {
@@ -4144,20 +4844,26 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "100",
             "speed": "81",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "214"
+            "base exp": "189"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gyarados.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gyarados.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gyarados.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gyarados.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gyarados.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gyarados.gif"
+         }
       }
    },
    {
@@ -4176,20 +4882,26 @@ const POKEDEX = [
             "sp atk": "85",
             "sp def": "95",
             "speed": "60",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Ice"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "219"
+            "base exp": "187"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lapras.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lapras.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lapras.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lapras.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lapras.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lapras.gif"
+         }
       }
    },
    {
@@ -4208,20 +4920,25 @@ const POKEDEX = [
             "sp atk": "48",
             "sp def": "48",
             "speed": "48",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "61"
+            "base exp": "101"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ditto.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ditto.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ditto.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ditto.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ditto.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ditto.gif"
+         }
       }
    },
    {
@@ -4240,20 +4957,25 @@ const POKEDEX = [
             "sp atk": "45",
             "sp def": "65",
             "speed": "55",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "92"
+            "base exp": "65"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/eevee.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/eevee.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/eevee.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/eevee.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/eevee.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/eevee.gif"
+         }
       }
    },
    {
@@ -4272,20 +4994,25 @@ const POKEDEX = [
             "sp atk": "110",
             "sp def": "95",
             "speed": "65",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "196"
+            "base exp": "184"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vaporeon.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vaporeon.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vaporeon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vaporeon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/vaporeon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/vaporeon.gif"
+         }
       }
    },
    {
@@ -4304,20 +5031,25 @@ const POKEDEX = [
             "sp atk": "110",
             "sp def": "95",
             "speed": "130",
-            "types": {
-               "text": "Electric",
-               "href": "https://pokemondb.net/type/electric"
-            }
+            "types": [
+               "Electric"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "197"
+            "base exp": "184"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/jolteon.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/jolteon.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/jolteon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/jolteon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/jolteon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/jolteon.gif"
+         }
       }
    },
    {
@@ -4336,20 +5068,25 @@ const POKEDEX = [
             "sp atk": "95",
             "sp def": "110",
             "speed": "65",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "198"
+            "base exp": "184"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/flareon.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/flareon.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/flareon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/flareon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/flareon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/flareon.gif"
+         }
       }
    },
    {
@@ -4368,20 +5105,25 @@ const POKEDEX = [
             "sp atk": "85",
             "sp def": "75",
             "speed": "40",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "130"
+            "base exp": "79"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/porygon.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/porygon.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/porygon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/porygon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/porygon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/porygon.gif"
+         }
       }
    },
    {
@@ -4400,20 +5142,26 @@ const POKEDEX = [
             "sp atk": "90",
             "sp def": "55",
             "speed": "35",
-            "types": {
-               "text": "Rock",
-               "href": "https://pokemondb.net/type/rock"
-            }
+            "types": [
+               "Rock",
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "99"
+            "base exp": "71"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/omanyte.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/omanyte.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/omanyte.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/omanyte.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/omanyte.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/omanyte.gif"
+         }
       }
    },
    {
@@ -4432,20 +5180,26 @@ const POKEDEX = [
             "sp atk": "115",
             "sp def": "70",
             "speed": "55",
-            "types": {
-               "text": "Rock",
-               "href": "https://pokemondb.net/type/rock"
-            }
+            "types": [
+               "Rock",
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "199"
+            "base exp": "173"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/omastar.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/omastar.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/omastar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/omastar.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/omastar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/omastar.gif"
+         }
       }
    },
    {
@@ -4464,20 +5218,26 @@ const POKEDEX = [
             "sp atk": "55",
             "sp def": "45",
             "speed": "55",
-            "types": {
-               "text": "Rock",
-               "href": "https://pokemondb.net/type/rock"
-            }
+            "types": [
+               "Rock",
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "99"
+            "base exp": "71"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kabuto.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kabuto.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kabuto.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kabuto.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kabuto.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kabuto.gif"
+         }
       }
    },
    {
@@ -4496,20 +5256,26 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "70",
             "speed": "80",
-            "types": {
-               "text": "Rock",
-               "href": "https://pokemondb.net/type/rock"
-            }
+            "types": [
+               "Rock",
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "199"
+            "base exp": "173"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kabutops.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kabutops.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kabutops.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kabutops.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kabutops.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kabutops.gif"
+         }
       }
    },
    {
@@ -4528,20 +5294,26 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "75",
             "speed": "130",
-            "types": {
-               "text": "Rock",
-               "href": "https://pokemondb.net/type/rock"
-            }
+            "types": [
+               "Rock",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "202"
+            "base exp": "180"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/aerodactyl.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/aerodactyl.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/aerodactyl.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/aerodactyl.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/aerodactyl.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/aerodactyl.gif"
+         }
       }
    },
    {
@@ -4560,20 +5332,25 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "110",
             "speed": "30",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "154"
+            "base exp": "189"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/snorlax.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/snorlax.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/snorlax.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/snorlax.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/snorlax.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/snorlax.gif"
+         }
       }
    },
    {
@@ -4586,26 +5363,32 @@ const POKEDEX = [
          {
             "catch rate": "3",
             "growth rate": "Slow",
-            "hp": "130",
-            "attack": "100",
-            "defense": "150",
+            "hp": "90",
+            "attack": "85",
+            "defense": "100",
             "sp atk": "95",
             "sp def": "125",
             "speed": "85",
-            "types": {
-               "text": "Ice",
-               "href": "https://pokemondb.net/type/ice"
-            }
+            "types": [
+               "Ice",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "215"
+            "base exp": "261"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/articuno.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/articuno.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/articuno.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/articuno.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/articuno.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/articuno.gif"
+         }
       }
    },
    {
@@ -4618,26 +5401,32 @@ const POKEDEX = [
          {
             "catch rate": "3",
             "growth rate": "Slow",
-            "hp": "150",
-            "attack": "130",
-            "defense": "100",
+            "hp": "90",
+            "attack": "90",
+            "defense": "85",
             "sp atk": "125",
             "sp def": "90",
             "speed": "100",
-            "types": {
-               "text": "Electric",
-               "href": "https://pokemondb.net/type/electric"
-            }
+            "types": [
+               "Electric",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "216"
+            "base exp": "261"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zapdos.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zapdos.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zapdos.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zapdos.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/zapdos.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/zapdos.gif"
+         }
       }
    },
    {
@@ -4650,26 +5439,32 @@ const POKEDEX = [
          {
             "catch rate": "3",
             "growth rate": "Slow",
-            "hp": "130",
-            "attack": "150",
-            "defense": "100",
-            "sp atk": "150",
+            "hp": "90",
+            "attack": "100",
+            "defense": "90",
+            "sp atk": "125",
             "sp def": "85",
             "speed": "90",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "217"
+            "base exp": "261"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/moltres.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/moltres.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/moltres.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/moltres.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/moltres.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/moltres.gif"
+         }
       }
    },
    {
@@ -4688,20 +5483,25 @@ const POKEDEX = [
             "sp atk": "50",
             "sp def": "50",
             "speed": "50",
-            "types": {
-               "text": "Dragon",
-               "href": "https://pokemondb.net/type/dragon"
-            }
+            "types": [
+               "Dragon"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "67"
+            "base exp": "60"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dratini.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dratini.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dratini.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dratini.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dratini.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dratini.gif"
+         }
       }
    },
    {
@@ -4720,20 +5520,25 @@ const POKEDEX = [
             "sp atk": "70",
             "sp def": "70",
             "speed": "70",
-            "types": {
-               "text": "Dragon",
-               "href": "https://pokemondb.net/type/dragon"
-            }
+            "types": [
+               "Dragon"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "144"
+            "base exp": "147"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dragonair.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dragonair.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dragonair.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dragonair.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dragonair.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dragonair.gif"
+         }
       }
    },
    {
@@ -4752,20 +5557,26 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "100",
             "speed": "80",
-            "types": {
-               "text": "Dragon",
-               "href": "https://pokemondb.net/type/dragon"
-            }
+            "types": [
+               "Dragon",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "218"
+            "base exp": "270"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dragonite.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dragonite.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dragonite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dragonite.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dragonite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dragonite.gif"
+         }
       }
    },
    {
@@ -4784,20 +5595,25 @@ const POKEDEX = [
             "sp atk": "154",
             "sp def": "90",
             "speed": "130",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "220"
+            "base exp": "306"
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mewtwo.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mewtwo.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mewtwo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mewtwo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mewtwo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mewtwo.gif"
+         }
       }
    },
    {
@@ -4816,10 +5632,46 @@ const POKEDEX = [
             "sp atk": "100",
             "sp def": "100",
             "speed": "100",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mew.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mew.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mew.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mew.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Chikorita"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "49",
+            "defense": "65",
+            "sp atk": "49",
+            "sp def": "65",
+            "speed": "45",
+            "types": [
+               "Grass"
+            ]
          }
       ],
       "exp": [
@@ -4828,11 +5680,21352 @@ const POKEDEX = [
          }
       ],
       "images": {
-         "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mew.gif",
-         "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mew.gif"
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/chikorita.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/chikorita.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/chikorita.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/chikorita.gif"
+         }
       }
    },
-//Mega1G
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bayleef"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "62",
+            "defense": "80",
+            "sp atk": "63",
+            "sp def": "80",
+            "speed": "60",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bayleef.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bayleef.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bayleef.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bayleef.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Meganium"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "80",
+            "attack": "82",
+            "defense": "100",
+            "sp atk": "83",
+            "sp def": "100",
+            "speed": "80",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "236"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/meganium.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/meganium.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/meganium.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/meganium.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cyndaquil"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "39",
+            "attack": "52",
+            "defense": "43",
+            "sp atk": "60",
+            "sp def": "50",
+            "speed": "65",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cyndaquil.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cyndaquil.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cyndaquil.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cyndaquil.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Quilava"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "58",
+            "attack": "64",
+            "defense": "58",
+            "sp atk": "80",
+            "sp def": "65",
+            "speed": "80",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/quilava.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/quilava.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/quilava.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/quilava.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Typhlosion"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "78",
+            "attack": "84",
+            "defense": "78",
+            "sp atk": "109",
+            "sp def": "85",
+            "speed": "100",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "240"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/typhlosion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/typhlosion.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/typhlosion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/typhlosion.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Totodile"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "65",
+            "defense": "64",
+            "sp atk": "44",
+            "sp def": "48",
+            "speed": "43",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "63"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/totodile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/totodile.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/totodile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/totodile.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Croconaw"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "65",
+            "attack": "80",
+            "defense": "80",
+            "sp atk": "59",
+            "sp def": "63",
+            "speed": "58",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/croconaw.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/croconaw.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/croconaw.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/croconaw.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Feraligatr"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "85",
+            "attack": "105",
+            "defense": "100",
+            "sp atk": "79",
+            "sp def": "83",
+            "speed": "78",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "239"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/feraligatr.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/feraligatr.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/feraligatr.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/feraligatr.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sentret"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "35",
+            "attack": "46",
+            "defense": "34",
+            "sp atk": "35",
+            "sp def": "45",
+            "speed": "20",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "43"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sentret.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sentret.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sentret.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sentret.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Furret"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "85",
+            "attack": "76",
+            "defense": "64",
+            "sp atk": "45",
+            "sp def": "55",
+            "speed": "90",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "145"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/furret.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/furret.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/furret.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/furret.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Hoothoot"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "30",
+            "defense": "30",
+            "sp atk": "36",
+            "sp def": "56",
+            "speed": "50",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "52"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hoothoot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hoothoot.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/hoothoot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/hoothoot.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Noctowl"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "100",
+            "attack": "50",
+            "defense": "50",
+            "sp atk": "76",
+            "sp def": "96",
+            "speed": "70",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "155"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/noctowl.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/noctowl.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/noctowl.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/noctowl.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ledyba"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Fast",
+            "hp": "40",
+            "attack": "20",
+            "defense": "30",
+            "sp atk": "40",
+            "sp def": "80",
+            "speed": "55",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "53"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ledyba.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ledyba.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ledyba.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ledyba.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ledian"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Fast",
+            "hp": "55",
+            "attack": "35",
+            "defense": "50",
+            "sp atk": "55",
+            "sp def": "110",
+            "speed": "85",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "137"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ledian.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ledian.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ledian.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ledian.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Spinarak"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Fast",
+            "hp": "40",
+            "attack": "60",
+            "defense": "40",
+            "sp atk": "40",
+            "sp def": "40",
+            "speed": "30",
+            "types": [
+               "Bug",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "50"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/spinarak.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/spinarak.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/spinarak.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/spinarak.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ariados"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Fast",
+            "hp": "70",
+            "attack": "90",
+            "defense": "70",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "40",
+            "types": [
+               "Bug",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "137"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ariados.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ariados.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ariados.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ariados.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Crobat"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "85",
+            "attack": "90",
+            "defense": "80",
+            "sp atk": "70",
+            "sp def": "80",
+            "speed": "130",
+            "types": [
+               "Poison",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "241"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/crobat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/crobat.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/crobat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/crobat.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Chinchou"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Slow",
+            "hp": "75",
+            "attack": "38",
+            "defense": "38",
+            "sp atk": "56",
+            "sp def": "56",
+            "speed": "67",
+            "types": [
+               "Water",
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/chinchou.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/chinchou.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/chinchou.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/chinchou.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lanturn"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Slow",
+            "hp": "125",
+            "attack": "58",
+            "defense": "58",
+            "sp atk": "76",
+            "sp def": "76",
+            "speed": "67",
+            "types": [
+               "Water",
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "161"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lanturn.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lanturn.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lanturn.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lanturn.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pichu"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "20",
+            "attack": "40",
+            "defense": "15",
+            "sp atk": "35",
+            "sp def": "35",
+            "speed": "60",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "41"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pichu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pichu.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pichu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pichu.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cleffa"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "150",
+            "growth rate": "Fast",
+            "hp": "50",
+            "attack": "25",
+            "defense": "28",
+            "sp atk": "45",
+            "sp def": "55",
+            "speed": "15",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "44"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cleffa.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cleffa.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cleffa.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cleffa.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Igglybuff"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "170",
+            "growth rate": "Fast",
+            "hp": "90",
+            "attack": "30",
+            "defense": "15",
+            "sp atk": "40",
+            "sp def": "20",
+            "speed": "15",
+            "types": [
+               "Normal",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "42"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/igglybuff.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/igglybuff.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/igglybuff.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/igglybuff.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Togepi"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Fast",
+            "hp": "35",
+            "attack": "20",
+            "defense": "65",
+            "sp atk": "40",
+            "sp def": "65",
+            "speed": "20",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "49"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/togepi.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/togepi.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/togepi.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/togepi.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Togetic"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Fast",
+            "hp": "55",
+            "attack": "40",
+            "defense": "85",
+            "sp atk": "80",
+            "sp def": "105",
+            "speed": "40",
+            "types": [
+               "Fairy",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/togetic.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/togetic.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/togetic.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/togetic.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Natu"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "40",
+            "attack": "50",
+            "defense": "45",
+            "sp atk": "70",
+            "sp def": "45",
+            "speed": "70",
+            "types": [
+               "Psychic",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "64"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/natu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/natu.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/natu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/natu.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Xatu"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "75",
+            "defense": "70",
+            "sp atk": "95",
+            "sp def": "70",
+            "speed": "95",
+            "types": [
+               "Psychic",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "165"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/xatu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/xatu.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/xatu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/xatu.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mareep"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "235",
+            "growth rate": "Medium Slow",
+            "hp": "55",
+            "attack": "40",
+            "defense": "40",
+            "sp atk": "65",
+            "sp def": "45",
+            "speed": "35",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "56"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mareep.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mareep.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mareep.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mareep.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Flaaffy"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "55",
+            "defense": "55",
+            "sp atk": "80",
+            "sp def": "60",
+            "speed": "45",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "128"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/flaaffy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/flaaffy.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/flaaffy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/flaaffy.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ampharos"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "90",
+            "attack": "75",
+            "defense": "85",
+            "sp atk": "115",
+            "sp def": "90",
+            "speed": "55",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "230"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ampharos.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ampharos.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ampharos.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ampharos.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bellossom"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "80",
+            "defense": "95",
+            "sp atk": "90",
+            "sp def": "100",
+            "speed": "50",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "221"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bellossom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bellossom.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bellossom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bellossom.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Marill"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Fast",
+            "hp": "70",
+            "attack": "20",
+            "defense": "50",
+            "sp atk": "20",
+            "sp def": "50",
+            "speed": "40",
+            "types": [
+               "Water",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "88"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/marill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/marill.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/marill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/marill.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Azumarill"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Fast",
+            "hp": "100",
+            "attack": "50",
+            "defense": "80",
+            "sp atk": "60",
+            "sp def": "80",
+            "speed": "50",
+            "types": [
+               "Water",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "189"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/azumarill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/azumarill.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/azumarill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/azumarill.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sudowoodo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "65",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "100",
+            "defense": "115",
+            "sp atk": "30",
+            "sp def": "65",
+            "speed": "30",
+            "types": [
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "144"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sudowoodo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sudowoodo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sudowoodo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sudowoodo.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Politoed"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "90",
+            "attack": "75",
+            "defense": "75",
+            "sp atk": "90",
+            "sp def": "100",
+            "speed": "70",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "225"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/politoed.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/politoed.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/politoed.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/politoed.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Hoppip"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "35",
+            "attack": "35",
+            "defense": "40",
+            "sp atk": "35",
+            "sp def": "55",
+            "speed": "50",
+            "types": [
+               "Grass",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "50"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hoppip.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hoppip.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/hoppip.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/hoppip.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Skiploom"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "55",
+            "attack": "45",
+            "defense": "50",
+            "sp atk": "45",
+            "sp def": "65",
+            "speed": "80",
+            "types": [
+               "Grass",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "119"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/skiploom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/skiploom.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/skiploom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/skiploom.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Jumpluff"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "55",
+            "defense": "70",
+            "sp atk": "55",
+            "sp def": "95",
+            "speed": "110",
+            "types": [
+               "Grass",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "207"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/jumpluff.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/jumpluff.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/jumpluff.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/jumpluff.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Aipom"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "55",
+            "attack": "70",
+            "defense": "55",
+            "sp atk": "40",
+            "sp def": "55",
+            "speed": "85",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "72"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/aipom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/aipom.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/aipom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/aipom.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sunkern"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "235",
+            "growth rate": "Medium Slow",
+            "hp": "30",
+            "attack": "30",
+            "defense": "30",
+            "sp atk": "30",
+            "sp def": "30",
+            "speed": "30",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "36"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sunkern.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sunkern.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sunkern.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sunkern.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sunflora"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "75",
+            "defense": "55",
+            "sp atk": "105",
+            "sp def": "85",
+            "speed": "30",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "149"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sunflora.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sunflora.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sunflora.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sunflora.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Yanma"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "65",
+            "defense": "45",
+            "sp atk": "75",
+            "sp def": "45",
+            "speed": "95",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "78"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/yanma.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/yanma.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/yanma.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/yanma.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Wooper"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "55",
+            "attack": "45",
+            "defense": "45",
+            "sp atk": "25",
+            "sp def": "25",
+            "speed": "15",
+            "types": [
+               "Water",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "42"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wooper.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wooper.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/wooper.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/wooper.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Quagsire"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "95",
+            "attack": "85",
+            "defense": "85",
+            "sp atk": "65",
+            "sp def": "65",
+            "speed": "35",
+            "types": [
+               "Water",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "151"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/quagsire.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/quagsire.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/quagsire.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/quagsire.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Espeon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "65",
+            "defense": "60",
+            "sp atk": "130",
+            "sp def": "95",
+            "speed": "110",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "184"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/espeon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/espeon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/espeon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/espeon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Umbreon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "95",
+            "attack": "65",
+            "defense": "110",
+            "sp atk": "60",
+            "sp def": "130",
+            "speed": "65",
+            "types": [
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "184"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/umbreon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/umbreon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/umbreon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/umbreon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Murkrow"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "85",
+            "defense": "42",
+            "sp atk": "85",
+            "sp def": "42",
+            "speed": "91",
+            "types": [
+               "Dark",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "81"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/murkrow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/murkrow.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/murkrow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/murkrow.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Slowking"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "70",
+            "growth rate": "Medium Fast",
+            "hp": "95",
+            "attack": "75",
+            "defense": "80",
+            "sp atk": "100",
+            "sp def": "110",
+            "speed": "30",
+            "types": [
+               "Water",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "172"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/slowking.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/slowking.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/slowking.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/slowking.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Misdreavus"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "60",
+            "attack": "60",
+            "defense": "60",
+            "sp atk": "85",
+            "sp def": "85",
+            "speed": "85",
+            "types": [
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "87"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/misdreavus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/misdreavus.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/misdreavus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/misdreavus.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Unown"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "225",
+            "growth rate": "Medium Fast",
+            "hp": "48",
+            "attack": "72",
+            "defense": "48",
+            "sp atk": "72",
+            "sp def": "48",
+            "speed": "48",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "118"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/unown.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/unown.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/unown.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/unown.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Wobbuffet"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "190",
+            "attack": "33",
+            "defense": "58",
+            "sp atk": "33",
+            "sp def": "58",
+            "speed": "33",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wobbuffet.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wobbuffet.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/wobbuffet.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/wobbuffet.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Girafarig"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "80",
+            "defense": "65",
+            "sp atk": "90",
+            "sp def": "65",
+            "speed": "85",
+            "types": [
+               "Normal",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "159"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/girafarig.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/girafarig.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/girafarig.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/girafarig.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pineco"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "65",
+            "defense": "90",
+            "sp atk": "35",
+            "sp def": "35",
+            "speed": "15",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pineco.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pineco.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pineco.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pineco.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Forretress"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "90",
+            "defense": "140",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "40",
+            "types": [
+               "Bug",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "163"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/forretress.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/forretress.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/forretress.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/forretress.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Dunsparce"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "100",
+            "attack": "70",
+            "defense": "70",
+            "sp atk": "65",
+            "sp def": "65",
+            "speed": "45",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "145"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dunsparce.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dunsparce.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dunsparce.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dunsparce.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gligar"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Slow",
+            "hp": "65",
+            "attack": "75",
+            "defense": "105",
+            "sp atk": "35",
+            "sp def": "65",
+            "speed": "85",
+            "types": [
+               "Ground",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "86"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gligar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gligar.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gligar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gligar.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Steelix"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "25",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "85",
+            "defense": "200",
+            "sp atk": "55",
+            "sp def": "65",
+            "speed": "30",
+            "types": [
+               "Steel",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "179"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/steelix.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/steelix.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/steelix.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/steelix.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Snubbull"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Fast",
+            "hp": "60",
+            "attack": "80",
+            "defense": "50",
+            "sp atk": "40",
+            "sp def": "40",
+            "speed": "30",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/snubbull.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/snubbull.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/snubbull.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/snubbull.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Granbull"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Fast",
+            "hp": "90",
+            "attack": "120",
+            "defense": "75",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "45",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "158"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/granbull.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/granbull.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/granbull.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/granbull.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Qwilfish"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "95",
+            "defense": "75",
+            "sp atk": "55",
+            "sp def": "55",
+            "speed": "85",
+            "types": [
+               "Water",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "86"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/qwilfish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/qwilfish.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/qwilfish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/qwilfish.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Scizor"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "25",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "130",
+            "defense": "100",
+            "sp atk": "55",
+            "sp def": "80",
+            "speed": "65",
+            "types": [
+               "Bug",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/scizor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/scizor.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/scizor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/scizor.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shuckle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Slow",
+            "hp": "20",
+            "attack": "10",
+            "defense": "230",
+            "sp atk": "10",
+            "sp def": "230",
+            "speed": "5",
+            "types": [
+               "Bug",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "177"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shuckle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shuckle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shuckle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shuckle.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Heracross"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "125",
+            "defense": "75",
+            "sp atk": "40",
+            "sp def": "95",
+            "speed": "85",
+            "types": [
+               "Bug",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/heracross.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/heracross.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/heracross.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/heracross.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sneasel"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Slow",
+            "hp": "55",
+            "attack": "95",
+            "defense": "55",
+            "sp atk": "35",
+            "sp def": "75",
+            "speed": "115",
+            "types": [
+               "Dark",
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "86"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sneasel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sneasel.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sneasel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sneasel.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Teddiursa"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "80",
+            "defense": "50",
+            "sp atk": "50",
+            "sp def": "50",
+            "speed": "40",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/teddiursa.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/teddiursa.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/teddiursa.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/teddiursa.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ursaring"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "90",
+            "attack": "130",
+            "defense": "75",
+            "sp atk": "75",
+            "sp def": "75",
+            "speed": "55",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ursaring.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ursaring.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ursaring.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ursaring.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Slugma"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "40",
+            "attack": "40",
+            "defense": "40",
+            "sp atk": "70",
+            "sp def": "40",
+            "speed": "20",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "50"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/slugma.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/slugma.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/slugma.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/slugma.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Magcargo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "50",
+            "defense": "120",
+            "sp atk": "80",
+            "sp def": "80",
+            "speed": "30",
+            "types": [
+               "Fire",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "144"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magcargo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magcargo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/magcargo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/magcargo.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Swinub"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "225",
+            "growth rate": "Slow",
+            "hp": "50",
+            "attack": "50",
+            "defense": "40",
+            "sp atk": "30",
+            "sp def": "30",
+            "speed": "50",
+            "types": [
+               "Ice",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "50"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/swinub.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/swinub.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/swinub.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/swinub.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Piloswine"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "100",
+            "defense": "80",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "50",
+            "types": [
+               "Ice",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "158"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/piloswine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/piloswine.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/piloswine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/piloswine.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Corsola"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Fast",
+            "hp": "55",
+            "attack": "55",
+            "defense": "85",
+            "sp atk": "65",
+            "sp def": "85",
+            "speed": "35",
+            "types": [
+               "Water",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "133"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/corsola.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/corsola.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/corsola.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/corsola.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Remoraid"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "35",
+            "attack": "65",
+            "defense": "35",
+            "sp atk": "65",
+            "sp def": "35",
+            "speed": "65",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/remoraid.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/remoraid.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/remoraid.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/remoraid.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Octillery"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "105",
+            "defense": "75",
+            "sp atk": "105",
+            "sp def": "75",
+            "speed": "45",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/octillery.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/octillery.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/octillery.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/octillery.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Delibird"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "45",
+            "attack": "55",
+            "defense": "45",
+            "sp atk": "65",
+            "sp def": "45",
+            "speed": "75",
+            "types": [
+               "Ice",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "116"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/delibird.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/delibird.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/delibird.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/delibird.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mantine"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "25",
+            "growth rate": "Slow",
+            "hp": "65",
+            "attack": "40",
+            "defense": "70",
+            "sp atk": "80",
+            "sp def": "140",
+            "speed": "70",
+            "types": [
+               "Water",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "163"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mantine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mantine.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mantine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mantine.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Skarmory"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "25",
+            "growth rate": "Slow",
+            "hp": "65",
+            "attack": "80",
+            "defense": "140",
+            "sp atk": "40",
+            "sp def": "70",
+            "speed": "70",
+            "types": [
+               "Steel",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "163"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/skarmory.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/skarmory.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/skarmory.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/skarmory.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Houndour"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Slow",
+            "hp": "45",
+            "attack": "60",
+            "defense": "30",
+            "sp atk": "80",
+            "sp def": "50",
+            "speed": "65",
+            "types": [
+               "Dark",
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/houndour.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/houndour.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/houndour.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/houndour.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Houndoom"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "75",
+            "attack": "90",
+            "defense": "50",
+            "sp atk": "110",
+            "sp def": "80",
+            "speed": "95",
+            "types": [
+               "Dark",
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/houndoom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/houndoom.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/houndoom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/houndoom.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Kingdra"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "95",
+            "defense": "95",
+            "sp atk": "95",
+            "sp def": "95",
+            "speed": "85",
+            "types": [
+               "Water",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "243"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kingdra.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kingdra.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kingdra.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kingdra.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Phanpy"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "90",
+            "attack": "60",
+            "defense": "60",
+            "sp atk": "40",
+            "sp def": "40",
+            "speed": "40",
+            "types": [
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/phanpy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/phanpy.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/phanpy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/phanpy.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Donphan"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "90",
+            "attack": "120",
+            "defense": "120",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "50",
+            "types": [
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/donphan.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/donphan.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/donphan.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/donphan.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Porygon2"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "85",
+            "attack": "80",
+            "defense": "90",
+            "sp atk": "105",
+            "sp def": "95",
+            "speed": "60",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "180"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/porygon2.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/porygon2.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/porygon2.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/porygon2.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Stantler"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "73",
+            "attack": "95",
+            "defense": "62",
+            "sp atk": "85",
+            "sp def": "65",
+            "speed": "85",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "163"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/stantler.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/stantler.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/stantler.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/stantler.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Smeargle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "55",
+            "attack": "20",
+            "defense": "35",
+            "sp atk": "20",
+            "sp def": "45",
+            "speed": "75",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "88"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/smeargle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/smeargle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/smeargle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/smeargle.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tyrogue"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "35",
+            "attack": "35",
+            "defense": "35",
+            "sp atk": "35",
+            "sp def": "35",
+            "speed": "35",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "42"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tyrogue.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tyrogue.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tyrogue.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tyrogue.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Hitmontop"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "95",
+            "defense": "95",
+            "sp atk": "35",
+            "sp def": "110",
+            "speed": "70",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "159"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hitmontop.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hitmontop.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/hitmontop.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/hitmontop.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Smoochum"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "30",
+            "defense": "15",
+            "sp atk": "85",
+            "sp def": "65",
+            "speed": "65",
+            "types": [
+               "Ice",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/smoochum.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/smoochum.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/smoochum.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/smoochum.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Elekid"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "63",
+            "defense": "37",
+            "sp atk": "65",
+            "sp def": "55",
+            "speed": "95",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "72"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/elekid.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/elekid.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/elekid.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/elekid.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Magby"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "75",
+            "defense": "37",
+            "sp atk": "70",
+            "sp def": "55",
+            "speed": "83",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "73"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magby.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magby.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/magby.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/magby.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Miltank"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "95",
+            "attack": "80",
+            "defense": "105",
+            "sp atk": "40",
+            "sp def": "70",
+            "speed": "100",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "172"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/miltank.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/miltank.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/miltank.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/miltank.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Blissey"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Fast",
+            "hp": "255",
+            "attack": "10",
+            "defense": "10",
+            "sp atk": "75",
+            "sp def": "135",
+            "speed": "55",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "608"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/blissey.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/blissey.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/blissey.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/blissey.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Raikou"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "90",
+            "attack": "85",
+            "defense": "75",
+            "sp atk": "115",
+            "sp def": "100",
+            "speed": "115",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/raikou.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/raikou.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/raikou.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/raikou.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Entei"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "115",
+            "attack": "115",
+            "defense": "85",
+            "sp atk": "90",
+            "sp def": "75",
+            "speed": "100",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/entei.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/entei.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/entei.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/entei.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Suicune"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "75",
+            "defense": "115",
+            "sp atk": "90",
+            "sp def": "115",
+            "speed": "85",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/suicune.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/suicune.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/suicune.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/suicune.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Larvitar"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "50",
+            "attack": "64",
+            "defense": "50",
+            "sp atk": "45",
+            "sp def": "50",
+            "speed": "41",
+            "types": [
+               "Rock",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/larvitar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/larvitar.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/larvitar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/larvitar.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pupitar"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "84",
+            "defense": "70",
+            "sp atk": "65",
+            "sp def": "70",
+            "speed": "51",
+            "types": [
+               "Rock",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "144"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pupitar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pupitar.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pupitar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pupitar.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tyranitar"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "134",
+            "defense": "110",
+            "sp atk": "95",
+            "sp def": "100",
+            "speed": "61",
+            "types": [
+               "Rock",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tyranitar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tyranitar.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tyranitar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tyranitar.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lugia"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "106",
+            "attack": "90",
+            "defense": "130",
+            "sp atk": "90",
+            "sp def": "154",
+            "speed": "110",
+            "types": [
+               "Psychic",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "306"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lugia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lugia.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lugia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lugia.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ho-oh"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "106",
+            "attack": "130",
+            "defense": "90",
+            "sp atk": "110",
+            "sp def": "154",
+            "speed": "90",
+            "types": [
+               "Fire",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "306"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ho-oh.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ho-oh.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ho-oh.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ho-oh.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Celebi"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "100",
+            "attack": "100",
+            "defense": "100",
+            "sp atk": "100",
+            "sp def": "100",
+            "speed": "100",
+            "types": [
+               "Psychic",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/celebi.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/celebi.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/celebi.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/celebi.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Treecko"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "45",
+            "defense": "35",
+            "sp atk": "65",
+            "sp def": "55",
+            "speed": "70",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/treecko.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/treecko.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/treecko.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/treecko.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Grovyle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "65",
+            "defense": "45",
+            "sp atk": "85",
+            "sp def": "65",
+            "speed": "95",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/grovyle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/grovyle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/grovyle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/grovyle.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sceptile"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "85",
+            "defense": "65",
+            "sp atk": "105",
+            "sp def": "85",
+            "speed": "120",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "239"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sceptile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sceptile.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sceptile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sceptile.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Torchic"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "60",
+            "defense": "40",
+            "sp atk": "70",
+            "sp def": "50",
+            "speed": "45",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/torchic.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/torchic.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/torchic.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/torchic.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Combusken"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "85",
+            "defense": "60",
+            "sp atk": "85",
+            "sp def": "60",
+            "speed": "55",
+            "types": [
+               "Fire",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/combusken.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/combusken.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/combusken.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/combusken.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Blaziken"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "80",
+            "attack": "120",
+            "defense": "70",
+            "sp atk": "110",
+            "sp def": "70",
+            "speed": "80",
+            "types": [
+               "Fire",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "239"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/blaziken.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/blaziken.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/blaziken.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/blaziken.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mudkip"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "70",
+            "defense": "50",
+            "sp atk": "50",
+            "sp def": "50",
+            "speed": "40",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mudkip.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mudkip.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mudkip.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mudkip.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Marshtomp"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "85",
+            "defense": "70",
+            "sp atk": "60",
+            "sp def": "70",
+            "speed": "50",
+            "types": [
+               "Water",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/marshtomp.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/marshtomp.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/marshtomp.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/marshtomp.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Swampert"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "100",
+            "attack": "110",
+            "defense": "90",
+            "sp atk": "85",
+            "sp def": "90",
+            "speed": "60",
+            "types": [
+               "Water",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "241"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/swampert.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/swampert.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/swampert.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/swampert.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Poochyena"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "35",
+            "attack": "55",
+            "defense": "35",
+            "sp atk": "30",
+            "sp def": "30",
+            "speed": "35",
+            "types": [
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "44"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/poochyena.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/poochyena.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/poochyena.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/poochyena.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mightyena"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "127",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "90",
+            "defense": "70",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "70",
+            "types": [
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "147"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mightyena.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mightyena.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mightyena.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mightyena.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Zigzagoon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "38",
+            "attack": "30",
+            "defense": "41",
+            "sp atk": "30",
+            "sp def": "41",
+            "speed": "60",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "48"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zigzagoon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zigzagoon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/zigzagoon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/zigzagoon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Linoone"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "78",
+            "attack": "70",
+            "defense": "61",
+            "sp atk": "50",
+            "sp def": "61",
+            "speed": "100",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "147"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/linoone.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/linoone.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/linoone.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/linoone.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Wurmple"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "45",
+            "defense": "35",
+            "sp atk": "20",
+            "sp def": "30",
+            "speed": "20",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "39"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wurmple.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wurmple.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/wurmple.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/wurmple.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Silcoon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "35",
+            "defense": "55",
+            "sp atk": "25",
+            "sp def": "25",
+            "speed": "15",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "72"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/silcoon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/silcoon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/silcoon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/silcoon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Beautifly"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "70",
+            "defense": "50",
+            "sp atk": "100",
+            "sp def": "50",
+            "speed": "65",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "178"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/beautifly.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/beautifly.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/beautifly.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/beautifly.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cascoon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "35",
+            "defense": "55",
+            "sp atk": "25",
+            "sp def": "25",
+            "speed": "15",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "41"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cascoon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cascoon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cascoon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cascoon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Dustox"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "50",
+            "defense": "70",
+            "sp atk": "50",
+            "sp def": "90",
+            "speed": "65",
+            "types": [
+               "Bug",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "135"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dustox.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dustox.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dustox.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dustox.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lotad"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "30",
+            "defense": "30",
+            "sp atk": "40",
+            "sp def": "50",
+            "speed": "30",
+            "types": [
+               "Water",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "44"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lotad.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lotad.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lotad.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lotad.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lombre"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "50",
+            "defense": "50",
+            "sp atk": "60",
+            "sp def": "70",
+            "speed": "50",
+            "types": [
+               "Water",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "119"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lombre.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lombre.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lombre.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lombre.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ludicolo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "80",
+            "attack": "70",
+            "defense": "70",
+            "sp atk": "90",
+            "sp def": "100",
+            "speed": "70",
+            "types": [
+               "Water",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "216"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ludicolo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ludicolo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ludicolo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ludicolo.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Seedot"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "40",
+            "defense": "50",
+            "sp atk": "30",
+            "sp def": "30",
+            "speed": "30",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "44"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/seedot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/seedot.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/seedot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/seedot.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Nuzleaf"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "70",
+            "defense": "40",
+            "sp atk": "60",
+            "sp def": "40",
+            "speed": "60",
+            "types": [
+               "Grass",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "119"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nuzleaf.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nuzleaf.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/nuzleaf.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/nuzleaf.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shiftry"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "90",
+            "attack": "100",
+            "defense": "60",
+            "sp atk": "90",
+            "sp def": "60",
+            "speed": "80",
+            "types": [
+               "Grass",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "216"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shiftry.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shiftry.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shiftry.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shiftry.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Taillow"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "55",
+            "defense": "30",
+            "sp atk": "30",
+            "sp def": "30",
+            "speed": "85",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "54"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/taillow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/taillow.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/taillow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/taillow.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Swellow"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "85",
+            "defense": "60",
+            "sp atk": "50",
+            "sp def": "50",
+            "speed": "125",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "151"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/swellow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/swellow.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/swellow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/swellow.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Wingull"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "40",
+            "attack": "30",
+            "defense": "30",
+            "sp atk": "55",
+            "sp def": "30",
+            "speed": "85",
+            "types": [
+               "Water",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "54"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wingull.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wingull.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/wingull.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/wingull.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pelipper"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "50",
+            "defense": "100",
+            "sp atk": "85",
+            "sp def": "70",
+            "speed": "65",
+            "types": [
+               "Water",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "151"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pelipper.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pelipper.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pelipper.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pelipper.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ralts"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "235",
+            "growth rate": "Slow",
+            "hp": "28",
+            "attack": "25",
+            "defense": "25",
+            "sp atk": "45",
+            "sp def": "35",
+            "speed": "40",
+            "types": [
+               "Psychic",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "40"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ralts.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ralts.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ralts.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ralts.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Kirlia"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Slow",
+            "hp": "38",
+            "attack": "35",
+            "defense": "35",
+            "sp atk": "65",
+            "sp def": "55",
+            "speed": "50",
+            "types": [
+               "Psychic",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "97"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kirlia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kirlia.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kirlia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kirlia.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gardevoir"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "68",
+            "attack": "65",
+            "defense": "65",
+            "sp atk": "125",
+            "sp def": "115",
+            "speed": "80",
+            "types": [
+               "Psychic",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "233"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gardevoir.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gardevoir.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gardevoir.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gardevoir.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Surskit"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Fast",
+            "hp": "40",
+            "attack": "30",
+            "defense": "32",
+            "sp atk": "50",
+            "sp def": "52",
+            "speed": "65",
+            "types": [
+               "Bug",
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "54"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/surskit.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/surskit.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/surskit.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/surskit.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Masquerain"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "60",
+            "defense": "62",
+            "sp atk": "80",
+            "sp def": "82",
+            "speed": "60",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "145"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/masquerain.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/masquerain.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/masquerain.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/masquerain.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shroomish"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Fast then very Slow",
+            "hp": "60",
+            "attack": "40",
+            "defense": "60",
+            "sp atk": "40",
+            "sp def": "60",
+            "speed": "35",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "59"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shroomish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shroomish.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shroomish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shroomish.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Breloom"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Fast then very Slow",
+            "hp": "60",
+            "attack": "130",
+            "defense": "80",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "70",
+            "types": [
+               "Grass",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "161"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/breloom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/breloom.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/breloom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/breloom.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Slakoth"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Slow",
+            "hp": "60",
+            "attack": "60",
+            "defense": "60",
+            "sp atk": "35",
+            "sp def": "35",
+            "speed": "30",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "56"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/slakoth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/slakoth.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/slakoth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/slakoth.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Vigoroth"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "80",
+            "defense": "80",
+            "sp atk": "55",
+            "sp def": "55",
+            "speed": "90",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "154"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vigoroth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vigoroth.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/vigoroth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/vigoroth.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Slaking"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "150",
+            "attack": "160",
+            "defense": "100",
+            "sp atk": "95",
+            "sp def": "65",
+            "speed": "100",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "252"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/slaking.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/slaking.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/slaking.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/slaking.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Nincada"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Slow then very Fast",
+            "hp": "31",
+            "attack": "45",
+            "defense": "90",
+            "sp atk": "30",
+            "sp def": "30",
+            "speed": "40",
+            "types": [
+               "Bug",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "53"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nincada.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nincada.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/nincada.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/nincada.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ninjask"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Slow then very Fast",
+            "hp": "61",
+            "attack": "90",
+            "defense": "45",
+            "sp atk": "50",
+            "sp def": "50",
+            "speed": "160",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "160"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ninjask.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ninjask.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ninjask.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ninjask.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shedinja"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "1",
+            "attack": "90",
+            "defense": "45",
+            "sp atk": "30",
+            "sp def": "30",
+            "speed": "40",
+            "types": [
+               "Bug",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "83"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shedinja.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shedinja.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shedinja.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shedinja.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Whismur"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Slow",
+            "hp": "64",
+            "attack": "51",
+            "defense": "23",
+            "sp atk": "51",
+            "sp def": "23",
+            "speed": "28",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "48"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/whismur.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/whismur.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/whismur.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/whismur.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Loudred"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "84",
+            "attack": "71",
+            "defense": "43",
+            "sp atk": "71",
+            "sp def": "43",
+            "speed": "48",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "126"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/loudred.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/loudred.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/loudred.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/loudred.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Exploud"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "104",
+            "attack": "91",
+            "defense": "63",
+            "sp atk": "91",
+            "sp def": "73",
+            "speed": "68",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "221"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/exploud.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/exploud.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/exploud.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/exploud.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Makuhita"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "180",
+            "growth rate": "Fast then very Slow",
+            "hp": "72",
+            "attack": "60",
+            "defense": "30",
+            "sp atk": "20",
+            "sp def": "30",
+            "speed": "25",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "47"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/makuhita.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/makuhita.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/makuhita.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/makuhita.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Hariyama"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Fast then very Slow",
+            "hp": "144",
+            "attack": "120",
+            "defense": "60",
+            "sp atk": "40",
+            "sp def": "60",
+            "speed": "50",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "166"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hariyama.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hariyama.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/hariyama.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/hariyama.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Azurill"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "150",
+            "growth rate": "Fast",
+            "hp": "50",
+            "attack": "20",
+            "defense": "40",
+            "sp atk": "20",
+            "sp def": "40",
+            "speed": "20",
+            "types": [
+               "Normal",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "38"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/azurill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/azurill.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/azurill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/azurill.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Nosepass"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "30",
+            "attack": "45",
+            "defense": "135",
+            "sp atk": "45",
+            "sp def": "90",
+            "speed": "30",
+            "types": [
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "75"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/nosepass.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/nosepass.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/nosepass.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/nosepass.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Skitty"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Fast",
+            "hp": "50",
+            "attack": "45",
+            "defense": "45",
+            "sp atk": "35",
+            "sp def": "35",
+            "speed": "50",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "52"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/skitty.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/skitty.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/skitty.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/skitty.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Delcatty"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Fast",
+            "hp": "70",
+            "attack": "65",
+            "defense": "65",
+            "sp atk": "55",
+            "sp def": "55",
+            "speed": "70",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "133"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/delcatty.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/delcatty.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/delcatty.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/delcatty.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sableye"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "75",
+            "defense": "75",
+            "sp atk": "65",
+            "sp def": "65",
+            "speed": "50",
+            "types": [
+               "Dark",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "133"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sableye.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sableye.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sableye.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sableye.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mawile"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "50",
+            "attack": "85",
+            "defense": "85",
+            "sp atk": "55",
+            "sp def": "55",
+            "speed": "50",
+            "types": [
+               "Steel",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "133"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mawile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mawile.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mawile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mawile.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Aron"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "180",
+            "growth rate": "Slow",
+            "hp": "50",
+            "attack": "70",
+            "defense": "100",
+            "sp atk": "40",
+            "sp def": "40",
+            "speed": "30",
+            "types": [
+               "Steel",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/aron.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/aron.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/aron.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/aron.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lairon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Slow",
+            "hp": "60",
+            "attack": "90",
+            "defense": "140",
+            "sp atk": "50",
+            "sp def": "50",
+            "speed": "40",
+            "types": [
+               "Steel",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "151"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lairon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lairon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lairon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lairon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Aggron"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "110",
+            "defense": "180",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "50",
+            "types": [
+               "Steel",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "239"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/aggron.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/aggron.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/aggron.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/aggron.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Meditite"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "180",
+            "growth rate": "Medium Fast",
+            "hp": "30",
+            "attack": "40",
+            "defense": "55",
+            "sp atk": "40",
+            "sp def": "55",
+            "speed": "60",
+            "types": [
+               "Fighting",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "56"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/meditite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/meditite.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/meditite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/meditite.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Medicham"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "60",
+            "defense": "75",
+            "sp atk": "60",
+            "sp def": "75",
+            "speed": "80",
+            "types": [
+               "Fighting",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "144"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/medicham.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/medicham.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/medicham.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/medicham.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Electrike"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Slow",
+            "hp": "40",
+            "attack": "45",
+            "defense": "40",
+            "sp atk": "65",
+            "sp def": "40",
+            "speed": "65",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "59"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/electrike.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/electrike.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/electrike.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/electrike.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Manectric"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "75",
+            "defense": "60",
+            "sp atk": "105",
+            "sp def": "60",
+            "speed": "105",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "166"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/manectric.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/manectric.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/manectric.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/manectric.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Plusle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "50",
+            "defense": "40",
+            "sp atk": "85",
+            "sp def": "75",
+            "speed": "95",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/plusle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/plusle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/plusle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/plusle.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Minun"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "40",
+            "defense": "50",
+            "sp atk": "75",
+            "sp def": "85",
+            "speed": "95",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/minun.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/minun.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/minun.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/minun.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Volbeat"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "150",
+            "growth rate": "Slow then very Fast",
+            "hp": "65",
+            "attack": "73",
+            "defense": "55",
+            "sp atk": "47",
+            "sp def": "75",
+            "speed": "85",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "140"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/volbeat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/volbeat.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/volbeat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/volbeat.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Illumise"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "150",
+            "growth rate": "Fast then very Slow",
+            "hp": "65",
+            "attack": "47",
+            "defense": "55",
+            "sp atk": "73",
+            "sp def": "75",
+            "speed": "85",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "140"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/illumise.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/illumise.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/illumise.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/illumise.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Roselia"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "150",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "60",
+            "defense": "45",
+            "sp atk": "100",
+            "sp def": "80",
+            "speed": "65",
+            "types": [
+               "Grass",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "140"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/roselia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/roselia.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/roselia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/roselia.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gulpin"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "225",
+            "growth rate": "Fast then very Slow",
+            "hp": "70",
+            "attack": "43",
+            "defense": "53",
+            "sp atk": "43",
+            "sp def": "53",
+            "speed": "40",
+            "types": [
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gulpin.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gulpin.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gulpin.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gulpin.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Swalot"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Fast then very Slow",
+            "hp": "100",
+            "attack": "73",
+            "defense": "83",
+            "sp atk": "73",
+            "sp def": "83",
+            "speed": "55",
+            "types": [
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "163"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/swalot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/swalot.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/swalot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/swalot.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Carvanha"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "225",
+            "growth rate": "Slow",
+            "hp": "45",
+            "attack": "90",
+            "defense": "20",
+            "sp atk": "65",
+            "sp def": "20",
+            "speed": "65",
+            "types": [
+               "Water",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/carvanha.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/carvanha.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/carvanha.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/carvanha.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sharpedo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "120",
+            "defense": "40",
+            "sp atk": "95",
+            "sp def": "40",
+            "speed": "95",
+            "types": [
+               "Water",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "161"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sharpedo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sharpedo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sharpedo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sharpedo.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Wailmer"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "125",
+            "growth rate": "Fast then very Slow",
+            "hp": "130",
+            "attack": "70",
+            "defense": "35",
+            "sp atk": "70",
+            "sp def": "35",
+            "speed": "60",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "80"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wailmer.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wailmer.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/wailmer.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/wailmer.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Wailord"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Fast then very Slow",
+            "hp": "170",
+            "attack": "90",
+            "defense": "45",
+            "sp atk": "90",
+            "sp def": "45",
+            "speed": "60",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wailord.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wailord.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/wailord.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/wailord.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Numel"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "60",
+            "defense": "40",
+            "sp atk": "65",
+            "sp def": "45",
+            "speed": "35",
+            "types": [
+               "Fire",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/numel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/numel.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/numel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/numel.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Camerupt"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "150",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "100",
+            "defense": "70",
+            "sp atk": "105",
+            "sp def": "75",
+            "speed": "40",
+            "types": [
+               "Fire",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "161"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/camerupt.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/camerupt.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/camerupt.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/camerupt.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Torkoal"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "85",
+            "defense": "140",
+            "sp atk": "85",
+            "sp def": "70",
+            "speed": "20",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "165"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/torkoal.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/torkoal.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/torkoal.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/torkoal.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Spoink"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Fast",
+            "hp": "60",
+            "attack": "25",
+            "defense": "35",
+            "sp atk": "70",
+            "sp def": "80",
+            "speed": "60",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/spoink.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/spoink.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/spoink.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/spoink.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Grumpig"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Fast",
+            "hp": "80",
+            "attack": "45",
+            "defense": "65",
+            "sp atk": "90",
+            "sp def": "110",
+            "speed": "80",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "165"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/grumpig.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/grumpig.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/grumpig.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/grumpig.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Spinda"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Fast",
+            "hp": "60",
+            "attack": "60",
+            "defense": "60",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "60",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "126"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/spinda.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/spinda.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/spinda.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/spinda.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Trapinch"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "100",
+            "defense": "45",
+            "sp atk": "45",
+            "sp def": "45",
+            "speed": "10",
+            "types": [
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/trapinch.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/trapinch.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/trapinch.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/trapinch.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Vibrava"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "70",
+            "defense": "50",
+            "sp atk": "50",
+            "sp def": "50",
+            "speed": "70",
+            "types": [
+               "Ground",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "119"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vibrava.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vibrava.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/vibrava.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/vibrava.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Flygon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "80",
+            "attack": "100",
+            "defense": "80",
+            "sp atk": "80",
+            "sp def": "80",
+            "speed": "100",
+            "types": [
+               "Ground",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "234"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/flygon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/flygon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/flygon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/flygon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cacnea"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "85",
+            "defense": "40",
+            "sp atk": "85",
+            "sp def": "40",
+            "speed": "35",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "67"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cacnea.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cacnea.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cacnea.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cacnea.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cacturne"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "115",
+            "defense": "60",
+            "sp atk": "115",
+            "sp def": "60",
+            "speed": "55",
+            "types": [
+               "Grass",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "166"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cacturne.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cacturne.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cacturne.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cacturne.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Swablu"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Slow then very Fast",
+            "hp": "45",
+            "attack": "40",
+            "defense": "60",
+            "sp atk": "40",
+            "sp def": "75",
+            "speed": "50",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/swablu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/swablu.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/swablu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/swablu.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Altaria"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "75",
+            "attack": "70",
+            "defense": "90",
+            "sp atk": "70",
+            "sp def": "105",
+            "speed": "80",
+            "types": [
+               "Dragon",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "172"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/altaria.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/altaria.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/altaria.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/altaria.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Zangoose"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Slow then very Fast",
+            "hp": "73",
+            "attack": "115",
+            "defense": "60",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "90",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "160"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zangoose.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zangoose.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/zangoose.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/zangoose.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Seviper"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Fast then very Slow",
+            "hp": "73",
+            "attack": "100",
+            "defense": "60",
+            "sp atk": "100",
+            "sp def": "60",
+            "speed": "65",
+            "types": [
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "160"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/seviper.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/seviper.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/seviper.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/seviper.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lunatone"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "70",
+            "attack": "55",
+            "defense": "65",
+            "sp atk": "95",
+            "sp def": "85",
+            "speed": "70",
+            "types": [
+               "Rock",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "154"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lunatone.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lunatone.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lunatone.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lunatone.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Solrock"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "70",
+            "attack": "95",
+            "defense": "85",
+            "sp atk": "55",
+            "sp def": "65",
+            "speed": "70",
+            "types": [
+               "Rock",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "154"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/solrock.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/solrock.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/solrock.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/solrock.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Barboach"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "48",
+            "defense": "43",
+            "sp atk": "46",
+            "sp def": "41",
+            "speed": "60",
+            "types": [
+               "Water",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/barboach.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/barboach.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/barboach.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/barboach.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Whiscash"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "110",
+            "attack": "78",
+            "defense": "73",
+            "sp atk": "76",
+            "sp def": "71",
+            "speed": "60",
+            "types": [
+               "Water",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "164"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/whiscash.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/whiscash.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/whiscash.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/whiscash.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Corphish"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "205",
+            "growth rate": "Fast then very Slow",
+            "hp": "43",
+            "attack": "80",
+            "defense": "65",
+            "sp atk": "50",
+            "sp def": "35",
+            "speed": "35",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/corphish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/corphish.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/corphish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/corphish.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Crawdaunt"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "155",
+            "growth rate": "Fast then very Slow",
+            "hp": "63",
+            "attack": "120",
+            "defense": "85",
+            "sp atk": "90",
+            "sp def": "55",
+            "speed": "55",
+            "types": [
+               "Water",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "164"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/crawdaunt.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/crawdaunt.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/crawdaunt.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/crawdaunt.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Baltoy"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "40",
+            "attack": "40",
+            "defense": "55",
+            "sp atk": "40",
+            "sp def": "70",
+            "speed": "55",
+            "types": [
+               "Ground",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/baltoy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/baltoy.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/baltoy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/baltoy.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Claydol"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "70",
+            "defense": "105",
+            "sp atk": "70",
+            "sp def": "120",
+            "speed": "75",
+            "types": [
+               "Ground",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/claydol.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/claydol.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/claydol.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/claydol.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lileep"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "66",
+            "attack": "41",
+            "defense": "77",
+            "sp atk": "61",
+            "sp def": "87",
+            "speed": "23",
+            "types": [
+               "Rock",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "71"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lileep.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lileep.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lileep.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lileep.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cradily"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "86",
+            "attack": "81",
+            "defense": "97",
+            "sp atk": "81",
+            "sp def": "107",
+            "speed": "43",
+            "types": [
+               "Rock",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cradily.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cradily.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cradily.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cradily.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Anorith"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "45",
+            "attack": "95",
+            "defense": "50",
+            "sp atk": "40",
+            "sp def": "50",
+            "speed": "75",
+            "types": [
+               "Rock",
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "71"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/anorith.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/anorith.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/anorith.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/anorith.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Armaldo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "75",
+            "attack": "125",
+            "defense": "100",
+            "sp atk": "70",
+            "sp def": "80",
+            "speed": "45",
+            "types": [
+               "Rock",
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/armaldo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/armaldo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/armaldo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/armaldo.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Feebas"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Slow then very Fast",
+            "hp": "20",
+            "attack": "15",
+            "defense": "20",
+            "sp atk": "10",
+            "sp def": "55",
+            "speed": "80",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "40"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/feebas.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/feebas.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/feebas.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/feebas.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Milotic"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow then very Fast",
+            "hp": "95",
+            "attack": "60",
+            "defense": "79",
+            "sp atk": "100",
+            "sp def": "125",
+            "speed": "81",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "189"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/milotic.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/milotic.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/milotic.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/milotic.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Castform"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "70",
+            "defense": "70",
+            "sp atk": "70",
+            "sp def": "70",
+            "speed": "70",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "147"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/castform.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/castform.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/castform.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/castform.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Kecleon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "90",
+            "defense": "70",
+            "sp atk": "60",
+            "sp def": "120",
+            "speed": "40",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "154"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kecleon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kecleon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kecleon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kecleon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shuppet"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "225",
+            "growth rate": "Fast",
+            "hp": "44",
+            "attack": "75",
+            "defense": "35",
+            "sp atk": "63",
+            "sp def": "33",
+            "speed": "45",
+            "types": [
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "59"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shuppet.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shuppet.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shuppet.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shuppet.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Banette"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "64",
+            "attack": "115",
+            "defense": "65",
+            "sp atk": "83",
+            "sp def": "63",
+            "speed": "65",
+            "types": [
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "159"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/banette.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/banette.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/banette.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/banette.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Duskull"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Fast",
+            "hp": "20",
+            "attack": "40",
+            "defense": "90",
+            "sp atk": "30",
+            "sp def": "90",
+            "speed": "25",
+            "types": [
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "59"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/duskull.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/duskull.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/duskull.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/duskull.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Dusclops"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Fast",
+            "hp": "40",
+            "attack": "70",
+            "defense": "130",
+            "sp atk": "60",
+            "sp def": "130",
+            "speed": "25",
+            "types": [
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "159"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dusclops.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dusclops.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dusclops.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dusclops.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tropius"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Slow",
+            "hp": "99",
+            "attack": "68",
+            "defense": "83",
+            "sp atk": "72",
+            "sp def": "87",
+            "speed": "51",
+            "types": [
+               "Grass",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "161"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tropius.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tropius.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tropius.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tropius.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Chimecho"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "65",
+            "attack": "50",
+            "defense": "70",
+            "sp atk": "95",
+            "sp def": "80",
+            "speed": "65",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "149"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/chimecho.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/chimecho.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/chimecho.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/chimecho.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Absol"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Slow",
+            "hp": "65",
+            "attack": "130",
+            "defense": "60",
+            "sp atk": "75",
+            "sp def": "60",
+            "speed": "75",
+            "types": [
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "163"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/absol.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/absol.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/absol.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/absol.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Wynaut"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "125",
+            "growth rate": "Medium Fast",
+            "hp": "95",
+            "attack": "23",
+            "defense": "48",
+            "sp atk": "23",
+            "sp def": "48",
+            "speed": "23",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "52"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wynaut.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wynaut.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/wynaut.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/wynaut.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Snorunt"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "50",
+            "defense": "50",
+            "sp atk": "50",
+            "sp def": "50",
+            "speed": "50",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/snorunt.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/snorunt.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/snorunt.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/snorunt.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Glalie"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "80",
+            "attack": "80",
+            "defense": "80",
+            "sp atk": "80",
+            "sp def": "80",
+            "speed": "80",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/glalie.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/glalie.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/glalie.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/glalie.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Spheal"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "40",
+            "defense": "50",
+            "sp atk": "55",
+            "sp def": "50",
+            "speed": "25",
+            "types": [
+               "Ice",
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/spheal.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/spheal.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/spheal.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/spheal.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sealeo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "90",
+            "attack": "60",
+            "defense": "70",
+            "sp atk": "75",
+            "sp def": "70",
+            "speed": "45",
+            "types": [
+               "Ice",
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "144"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sealeo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sealeo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sealeo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sealeo.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Walrein"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "110",
+            "attack": "80",
+            "defense": "90",
+            "sp atk": "95",
+            "sp def": "90",
+            "speed": "65",
+            "types": [
+               "Ice",
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "239"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/walrein.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/walrein.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/walrein.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/walrein.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Clamperl"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Slow then very Fast",
+            "hp": "35",
+            "attack": "64",
+            "defense": "85",
+            "sp atk": "74",
+            "sp def": "55",
+            "speed": "32",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "69"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/clamperl.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/clamperl.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/clamperl.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/clamperl.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Huntail"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow then very Fast",
+            "hp": "55",
+            "attack": "104",
+            "defense": "105",
+            "sp atk": "94",
+            "sp def": "75",
+            "speed": "52",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "170"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/huntail.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/huntail.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/huntail.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/huntail.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gorebyss"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow then very Fast",
+            "hp": "55",
+            "attack": "84",
+            "defense": "105",
+            "sp atk": "114",
+            "sp def": "75",
+            "speed": "52",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "170"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gorebyss.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gorebyss.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gorebyss.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gorebyss.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Relicanth"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "25",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "90",
+            "defense": "130",
+            "sp atk": "45",
+            "sp def": "65",
+            "speed": "55",
+            "types": [
+               "Water",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "170"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/relicanth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/relicanth.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/relicanth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/relicanth.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Luvdisc"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "225",
+            "growth rate": "Fast",
+            "hp": "43",
+            "attack": "30",
+            "defense": "55",
+            "sp atk": "40",
+            "sp def": "65",
+            "speed": "97",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "116"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/luvdisc.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/luvdisc.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/luvdisc.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/luvdisc.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bagon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "45",
+            "attack": "75",
+            "defense": "60",
+            "sp atk": "40",
+            "sp def": "30",
+            "speed": "50",
+            "types": [
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bagon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bagon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bagon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bagon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shelgon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "65",
+            "attack": "95",
+            "defense": "100",
+            "sp atk": "60",
+            "sp def": "50",
+            "speed": "50",
+            "types": [
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "147"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shelgon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shelgon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shelgon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shelgon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Salamence"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "95",
+            "attack": "135",
+            "defense": "80",
+            "sp atk": "110",
+            "sp def": "80",
+            "speed": "100",
+            "types": [
+               "Dragon",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/salamence.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/salamence.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/salamence.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/salamence.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Beldum"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "40",
+            "attack": "55",
+            "defense": "80",
+            "sp atk": "35",
+            "sp def": "60",
+            "speed": "30",
+            "types": [
+               "Steel",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/beldum.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/beldum.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/beldum.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/beldum.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Metang"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "60",
+            "attack": "75",
+            "defense": "100",
+            "sp atk": "55",
+            "sp def": "80",
+            "speed": "50",
+            "types": [
+               "Steel",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "147"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/metang.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/metang.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/metang.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/metang.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Metagross"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "135",
+            "defense": "130",
+            "sp atk": "95",
+            "sp def": "90",
+            "speed": "70",
+            "types": [
+               "Steel",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/metagross.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/metagross.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/metagross.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/metagross.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Regirock"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "100",
+            "defense": "200",
+            "sp atk": "50",
+            "sp def": "100",
+            "speed": "50",
+            "types": [
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/regirock.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/regirock.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/regirock.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/regirock.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Regice"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "50",
+            "defense": "100",
+            "sp atk": "100",
+            "sp def": "200",
+            "speed": "50",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/regice.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/regice.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/regice.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/regice.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Registeel"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "75",
+            "defense": "150",
+            "sp atk": "75",
+            "sp def": "150",
+            "speed": "50",
+            "types": [
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/registeel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/registeel.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/registeel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/registeel.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Latias"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "80",
+            "defense": "90",
+            "sp atk": "110",
+            "sp def": "130",
+            "speed": "110",
+            "types": [
+               "Dragon",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/latias.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/latias.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/latias.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/latias.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Latios"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "90",
+            "defense": "80",
+            "sp atk": "130",
+            "sp def": "110",
+            "speed": "110",
+            "types": [
+               "Dragon",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/latios.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/latios.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/latios.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/latios.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Kyogre"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "5",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "100",
+            "defense": "90",
+            "sp atk": "150",
+            "sp def": "140",
+            "speed": "90",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "302"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kyogre.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kyogre.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kyogre.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kyogre.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Groudon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "5",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "150",
+            "defense": "140",
+            "sp atk": "100",
+            "sp def": "90",
+            "speed": "90",
+            "types": [
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "302"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/groudon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/groudon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/groudon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/groudon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Rayquaza"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "105",
+            "attack": "150",
+            "defense": "90",
+            "sp atk": "150",
+            "sp def": "90",
+            "speed": "95",
+            "types": [
+               "Dragon",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "306"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rayquaza.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rayquaza.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/rayquaza.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/rayquaza.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Jirachi"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "100",
+            "defense": "100",
+            "sp atk": "100",
+            "sp def": "100",
+            "speed": "100",
+            "types": [
+               "Steel",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/jirachi.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/jirachi.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/jirachi.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/jirachi.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Deoxys-normal"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "50",
+            "attack": "150",
+            "defense": "50",
+            "sp atk": "150",
+            "sp def": "50",
+            "speed": "150",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/deoxys-normal.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/deoxys-normal.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/deoxys-normal.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/deoxys-normal.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Turtwig"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "55",
+            "attack": "68",
+            "defense": "64",
+            "sp atk": "45",
+            "sp def": "55",
+            "speed": "31",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "64"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/turtwig.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/turtwig.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/turtwig.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/turtwig.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Grotle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "89",
+            "defense": "85",
+            "sp atk": "55",
+            "sp def": "65",
+            "speed": "36",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/grotle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/grotle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/grotle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/grotle.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Torterra"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "95",
+            "attack": "109",
+            "defense": "105",
+            "sp atk": "75",
+            "sp def": "85",
+            "speed": "56",
+            "types": [
+               "Grass",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "236"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/torterra.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/torterra.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/torterra.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/torterra.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Chimchar"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "44",
+            "attack": "58",
+            "defense": "44",
+            "sp atk": "58",
+            "sp def": "44",
+            "speed": "61",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/chimchar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/chimchar.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/chimchar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/chimchar.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Monferno"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "64",
+            "attack": "78",
+            "defense": "52",
+            "sp atk": "78",
+            "sp def": "52",
+            "speed": "81",
+            "types": [
+               "Fire",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/monferno.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/monferno.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/monferno.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/monferno.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Infernape"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "76",
+            "attack": "104",
+            "defense": "71",
+            "sp atk": "104",
+            "sp def": "71",
+            "speed": "108",
+            "types": [
+               "Fire",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "240"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/infernape.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/infernape.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/infernape.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/infernape.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Piplup"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "53",
+            "attack": "51",
+            "defense": "53",
+            "sp atk": "61",
+            "sp def": "56",
+            "speed": "40",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "63"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/piplup.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/piplup.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/piplup.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/piplup.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Prinplup"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "64",
+            "attack": "66",
+            "defense": "68",
+            "sp atk": "81",
+            "sp def": "76",
+            "speed": "50",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/prinplup.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/prinplup.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/prinplup.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/prinplup.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Empoleon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "84",
+            "attack": "86",
+            "defense": "88",
+            "sp atk": "111",
+            "sp def": "101",
+            "speed": "60",
+            "types": [
+               "Water",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "239"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/empoleon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/empoleon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/empoleon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/empoleon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Starly"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "55",
+            "defense": "30",
+            "sp atk": "30",
+            "sp def": "30",
+            "speed": "60",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "49"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/starly.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/starly.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/starly.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/starly.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Staravia"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "55",
+            "attack": "75",
+            "defense": "50",
+            "sp atk": "40",
+            "sp def": "40",
+            "speed": "80",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "119"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/staravia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/staravia.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/staravia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/staravia.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Staraptor"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "85",
+            "attack": "120",
+            "defense": "70",
+            "sp atk": "50",
+            "sp def": "60",
+            "speed": "100",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "218"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/staraptor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/staraptor.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/staraptor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/staraptor.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bidoof"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "59",
+            "attack": "45",
+            "defense": "40",
+            "sp atk": "35",
+            "sp def": "40",
+            "speed": "31",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "50"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bidoof.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bidoof.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bidoof.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bidoof.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bibarel"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "127",
+            "growth rate": "Medium Fast",
+            "hp": "79",
+            "attack": "85",
+            "defense": "60",
+            "sp atk": "55",
+            "sp def": "60",
+            "speed": "71",
+            "types": [
+               "Normal",
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "144"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bibarel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bibarel.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bibarel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bibarel.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Kricketot"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "37",
+            "attack": "25",
+            "defense": "41",
+            "sp atk": "25",
+            "sp def": "41",
+            "speed": "25",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "39"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kricketot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kricketot.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kricketot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kricketot.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Kricketune"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "77",
+            "attack": "85",
+            "defense": "51",
+            "sp atk": "55",
+            "sp def": "51",
+            "speed": "65",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "134"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kricketune.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kricketune.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kricketune.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kricketune.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shinx"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "235",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "65",
+            "defense": "34",
+            "sp atk": "40",
+            "sp def": "34",
+            "speed": "45",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "53"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shinx.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shinx.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shinx.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shinx.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Luxio"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "85",
+            "defense": "49",
+            "sp atk": "60",
+            "sp def": "49",
+            "speed": "60",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "127"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/luxio.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/luxio.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/luxio.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/luxio.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Luxray"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "80",
+            "attack": "120",
+            "defense": "79",
+            "sp atk": "95",
+            "sp def": "79",
+            "speed": "70",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "235"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/luxray.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/luxray.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/luxray.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/luxray.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Budew"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "30",
+            "defense": "35",
+            "sp atk": "50",
+            "sp def": "70",
+            "speed": "55",
+            "types": [
+               "Grass",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "56"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/budew.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/budew.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/budew.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/budew.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Roserade"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "70",
+            "defense": "65",
+            "sp atk": "125",
+            "sp def": "105",
+            "speed": "90",
+            "types": [
+               "Grass",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "232"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/roserade.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/roserade.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/roserade.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/roserade.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cranidos"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "67",
+            "attack": "125",
+            "defense": "40",
+            "sp atk": "30",
+            "sp def": "30",
+            "speed": "58",
+            "types": [
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "70"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cranidos.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cranidos.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cranidos.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cranidos.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Rampardos"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "97",
+            "attack": "165",
+            "defense": "60",
+            "sp atk": "65",
+            "sp def": "50",
+            "speed": "58",
+            "types": [
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rampardos.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rampardos.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/rampardos.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/rampardos.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shieldon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "30",
+            "attack": "42",
+            "defense": "118",
+            "sp atk": "42",
+            "sp def": "88",
+            "speed": "30",
+            "types": [
+               "Rock",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "70"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shieldon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shieldon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shieldon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shieldon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bastiodon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "60",
+            "attack": "52",
+            "defense": "168",
+            "sp atk": "47",
+            "sp def": "138",
+            "speed": "30",
+            "types": [
+               "Rock",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bastiodon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bastiodon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bastiodon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bastiodon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Burmy"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "40",
+            "attack": "29",
+            "defense": "45",
+            "sp atk": "29",
+            "sp def": "45",
+            "speed": "36",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "45"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/burmy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/burmy.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/burmy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/burmy.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Wormadam-plant"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "59",
+            "defense": "85",
+            "sp atk": "79",
+            "sp def": "105",
+            "speed": "36",
+            "types": [
+               "Bug",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "148"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/wormadam-plant.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/wormadam-plant.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/wormadam-plant.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/wormadam-plant.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mothim"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "94",
+            "defense": "50",
+            "sp atk": "94",
+            "sp def": "50",
+            "speed": "66",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "148"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mothim.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mothim.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mothim.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mothim.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Combee"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "30",
+            "attack": "30",
+            "defense": "42",
+            "sp atk": "30",
+            "sp def": "42",
+            "speed": "70",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "49"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/combee.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/combee.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/combee.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/combee.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Vespiquen"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "80",
+            "defense": "102",
+            "sp atk": "80",
+            "sp def": "102",
+            "speed": "40",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "166"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vespiquen.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vespiquen.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/vespiquen.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/vespiquen.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pachirisu"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "45",
+            "defense": "70",
+            "sp atk": "45",
+            "sp def": "90",
+            "speed": "95",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pachirisu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pachirisu.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pachirisu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pachirisu.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Buizel"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "55",
+            "attack": "65",
+            "defense": "35",
+            "sp atk": "60",
+            "sp def": "30",
+            "speed": "85",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/buizel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/buizel.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/buizel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/buizel.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Floatzel"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "85",
+            "attack": "105",
+            "defense": "55",
+            "sp atk": "85",
+            "sp def": "50",
+            "speed": "115",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/floatzel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/floatzel.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/floatzel.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/floatzel.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cherubi"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "35",
+            "defense": "45",
+            "sp atk": "62",
+            "sp def": "53",
+            "speed": "35",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "55"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cherubi.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cherubi.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cherubi.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cherubi.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cherrim"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "60",
+            "defense": "70",
+            "sp atk": "87",
+            "sp def": "78",
+            "speed": "85",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "158"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cherrim.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cherrim.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cherrim.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cherrim.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shellos"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "76",
+            "attack": "48",
+            "defense": "48",
+            "sp atk": "57",
+            "sp def": "62",
+            "speed": "34",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "65"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shellos.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shellos.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shellos.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shellos.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gastrodon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "111",
+            "attack": "83",
+            "defense": "68",
+            "sp atk": "92",
+            "sp def": "82",
+            "speed": "39",
+            "types": [
+               "Water",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "166"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gastrodon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gastrodon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gastrodon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gastrodon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ambipom"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "75",
+            "attack": "100",
+            "defense": "66",
+            "sp atk": "60",
+            "sp def": "66",
+            "speed": "115",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "169"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ambipom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ambipom.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ambipom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ambipom.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Drifloon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "125",
+            "growth rate": "Fast then very Slow",
+            "hp": "90",
+            "attack": "50",
+            "defense": "34",
+            "sp atk": "60",
+            "sp def": "44",
+            "speed": "70",
+            "types": [
+               "Ghost",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "70"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/drifloon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/drifloon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/drifloon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/drifloon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Drifblim"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Fast then very Slow",
+            "hp": "150",
+            "attack": "80",
+            "defense": "44",
+            "sp atk": "90",
+            "sp def": "54",
+            "speed": "80",
+            "types": [
+               "Ghost",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "174"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/drifblim.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/drifblim.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/drifblim.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/drifblim.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Buneary"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "55",
+            "attack": "66",
+            "defense": "44",
+            "sp atk": "44",
+            "sp def": "56",
+            "speed": "85",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "70"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/buneary.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/buneary.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/buneary.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/buneary.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lopunny"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "76",
+            "defense": "84",
+            "sp atk": "54",
+            "sp def": "96",
+            "speed": "105",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lopunny.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lopunny.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lopunny.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lopunny.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mismagius"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "60",
+            "attack": "60",
+            "defense": "60",
+            "sp atk": "105",
+            "sp def": "105",
+            "speed": "105",
+            "types": [
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mismagius.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mismagius.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mismagius.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mismagius.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Honchkrow"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Slow",
+            "hp": "100",
+            "attack": "125",
+            "defense": "52",
+            "sp atk": "105",
+            "sp def": "52",
+            "speed": "71",
+            "types": [
+               "Dark",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "177"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/honchkrow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/honchkrow.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/honchkrow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/honchkrow.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Glameow"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Fast",
+            "hp": "49",
+            "attack": "55",
+            "defense": "42",
+            "sp atk": "42",
+            "sp def": "37",
+            "speed": "85",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/glameow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/glameow.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/glameow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/glameow.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Purugly"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Fast",
+            "hp": "71",
+            "attack": "82",
+            "defense": "64",
+            "sp atk": "64",
+            "sp def": "59",
+            "speed": "112",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "158"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/purugly.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/purugly.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/purugly.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/purugly.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Chingling"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Fast",
+            "hp": "45",
+            "attack": "30",
+            "defense": "50",
+            "sp atk": "65",
+            "sp def": "50",
+            "speed": "45",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "57"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/chingling.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/chingling.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/chingling.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/chingling.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Stunky"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "225",
+            "growth rate": "Medium Fast",
+            "hp": "63",
+            "attack": "63",
+            "defense": "47",
+            "sp atk": "41",
+            "sp def": "41",
+            "speed": "74",
+            "types": [
+               "Poison",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/stunky.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/stunky.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/stunky.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/stunky.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Skuntank"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "103",
+            "attack": "93",
+            "defense": "67",
+            "sp atk": "71",
+            "sp def": "61",
+            "speed": "84",
+            "types": [
+               "Poison",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/skuntank.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/skuntank.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/skuntank.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/skuntank.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bronzor"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "57",
+            "attack": "24",
+            "defense": "86",
+            "sp atk": "24",
+            "sp def": "86",
+            "speed": "23",
+            "types": [
+               "Steel",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bronzor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bronzor.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bronzor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bronzor.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bronzong"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "67",
+            "attack": "89",
+            "defense": "116",
+            "sp atk": "79",
+            "sp def": "116",
+            "speed": "33",
+            "types": [
+               "Steel",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bronzong.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bronzong.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bronzong.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bronzong.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bonsly"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "80",
+            "defense": "95",
+            "sp atk": "10",
+            "sp def": "45",
+            "speed": "10",
+            "types": [
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bonsly.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bonsly.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bonsly.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bonsly.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mime-jr"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "145",
+            "growth rate": "Medium Fast",
+            "hp": "20",
+            "attack": "25",
+            "defense": "45",
+            "sp atk": "70",
+            "sp def": "90",
+            "speed": "60",
+            "types": [
+               "Psychic",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mime-jr.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mime-jr.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mime-jr.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mime-jr.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Happiny"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "130",
+            "growth rate": "Fast",
+            "hp": "100",
+            "attack": "5",
+            "defense": "5",
+            "sp atk": "15",
+            "sp def": "65",
+            "speed": "30",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "110"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/happiny.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/happiny.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/happiny.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/happiny.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Chatot"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Slow",
+            "hp": "76",
+            "attack": "65",
+            "defense": "45",
+            "sp atk": "92",
+            "sp def": "42",
+            "speed": "91",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "144"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/chatot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/chatot.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/chatot.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/chatot.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Spiritomb"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "100",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "92",
+            "defense": "108",
+            "sp atk": "92",
+            "sp def": "108",
+            "speed": "35",
+            "types": [
+               "Ghost",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "170"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/spiritomb.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/spiritomb.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/spiritomb.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/spiritomb.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gible"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "58",
+            "attack": "70",
+            "defense": "45",
+            "sp atk": "40",
+            "sp def": "45",
+            "speed": "42",
+            "types": [
+               "Dragon",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gible.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gible.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gible.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gible.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gabite"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "68",
+            "attack": "90",
+            "defense": "65",
+            "sp atk": "50",
+            "sp def": "55",
+            "speed": "82",
+            "types": [
+               "Dragon",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "144"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gabite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gabite.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gabite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gabite.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Garchomp"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "108",
+            "attack": "130",
+            "defense": "95",
+            "sp atk": "80",
+            "sp def": "85",
+            "speed": "102",
+            "types": [
+               "Dragon",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/garchomp.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/garchomp.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/garchomp.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/garchomp.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Munchlax"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "50",
+            "growth rate": "Slow",
+            "hp": "135",
+            "attack": "85",
+            "defense": "40",
+            "sp atk": "40",
+            "sp def": "85",
+            "speed": "5",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "78"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/munchlax.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/munchlax.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/munchlax.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/munchlax.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Riolu"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "70",
+            "defense": "40",
+            "sp atk": "35",
+            "sp def": "40",
+            "speed": "60",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "57"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/riolu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/riolu.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/riolu.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/riolu.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lucario"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "110",
+            "defense": "70",
+            "sp atk": "115",
+            "sp def": "70",
+            "speed": "90",
+            "types": [
+               "Fighting",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "184"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lucario.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lucario.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lucario.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lucario.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Hippopotas"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "140",
+            "growth rate": "Slow",
+            "hp": "68",
+            "attack": "72",
+            "defense": "78",
+            "sp atk": "38",
+            "sp def": "42",
+            "speed": "32",
+            "types": [
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hippopotas.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hippopotas.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/hippopotas.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/hippopotas.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Hippowdon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow",
+            "hp": "108",
+            "attack": "112",
+            "defense": "118",
+            "sp atk": "68",
+            "sp def": "72",
+            "speed": "47",
+            "types": [
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "184"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hippowdon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hippowdon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/hippowdon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/hippowdon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Skorupi"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Slow",
+            "hp": "40",
+            "attack": "50",
+            "defense": "90",
+            "sp atk": "30",
+            "sp def": "55",
+            "speed": "65",
+            "types": [
+               "Poison",
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/skorupi.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/skorupi.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/skorupi.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/skorupi.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Drapion"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "90",
+            "defense": "110",
+            "sp atk": "60",
+            "sp def": "75",
+            "speed": "95",
+            "types": [
+               "Poison",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/drapion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/drapion.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/drapion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/drapion.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Croagunk"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "140",
+            "growth rate": "Medium Fast",
+            "hp": "48",
+            "attack": "61",
+            "defense": "40",
+            "sp atk": "61",
+            "sp def": "40",
+            "speed": "50",
+            "types": [
+               "Poison",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/croagunk.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/croagunk.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/croagunk.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/croagunk.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Toxicroak"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "83",
+            "attack": "106",
+            "defense": "65",
+            "sp atk": "86",
+            "sp def": "65",
+            "speed": "85",
+            "types": [
+               "Poison",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "172"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/toxicroak.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/toxicroak.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/toxicroak.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/toxicroak.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Carnivine"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Slow",
+            "hp": "74",
+            "attack": "100",
+            "defense": "72",
+            "sp atk": "90",
+            "sp def": "72",
+            "speed": "46",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "159"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/carnivine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/carnivine.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/carnivine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/carnivine.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Finneon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Slow then very Fast",
+            "hp": "49",
+            "attack": "49",
+            "defense": "56",
+            "sp atk": "49",
+            "sp def": "61",
+            "speed": "66",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/finneon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/finneon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/finneon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/finneon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lumineon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Slow then very Fast",
+            "hp": "69",
+            "attack": "69",
+            "defense": "76",
+            "sp atk": "69",
+            "sp def": "86",
+            "speed": "91",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "161"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lumineon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lumineon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lumineon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lumineon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mantyke"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "25",
+            "growth rate": "Slow",
+            "hp": "45",
+            "attack": "20",
+            "defense": "50",
+            "sp atk": "60",
+            "sp def": "120",
+            "speed": "50",
+            "types": [
+               "Water",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "69"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mantyke.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mantyke.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mantyke.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mantyke.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Snover"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Slow",
+            "hp": "60",
+            "attack": "62",
+            "defense": "50",
+            "sp atk": "62",
+            "sp def": "60",
+            "speed": "40",
+            "types": [
+               "Grass",
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "67"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/snover.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/snover.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/snover.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/snover.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Abomasnow"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow",
+            "hp": "90",
+            "attack": "92",
+            "defense": "75",
+            "sp atk": "92",
+            "sp def": "85",
+            "speed": "60",
+            "types": [
+               "Grass",
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/abomasnow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/abomasnow.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/abomasnow.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/abomasnow.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Weavile"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "120",
+            "defense": "65",
+            "sp atk": "45",
+            "sp def": "85",
+            "speed": "125",
+            "types": [
+               "Dark",
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "179"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/weavile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/weavile.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/weavile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/weavile.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Magnezone"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "70",
+            "defense": "115",
+            "sp atk": "130",
+            "sp def": "90",
+            "speed": "60",
+            "types": [
+               "Electric",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "241"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magnezone.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magnezone.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/magnezone.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/magnezone.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lickilicky"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Fast",
+            "hp": "110",
+            "attack": "85",
+            "defense": "95",
+            "sp atk": "80",
+            "sp def": "95",
+            "speed": "50",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "180"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lickilicky.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lickilicky.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lickilicky.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lickilicky.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Rhyperior"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Slow",
+            "hp": "115",
+            "attack": "140",
+            "defense": "130",
+            "sp atk": "55",
+            "sp def": "55",
+            "speed": "40",
+            "types": [
+               "Ground",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "241"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rhyperior.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rhyperior.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/rhyperior.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/rhyperior.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tangrowth"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Fast",
+            "hp": "100",
+            "attack": "100",
+            "defense": "125",
+            "sp atk": "110",
+            "sp def": "50",
+            "speed": "50",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "187"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tangrowth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tangrowth.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tangrowth.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tangrowth.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Electivire"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "123",
+            "defense": "67",
+            "sp atk": "95",
+            "sp def": "85",
+            "speed": "95",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "243"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/electivire.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/electivire.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/electivire.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/electivire.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Magmortar"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "95",
+            "defense": "67",
+            "sp atk": "125",
+            "sp def": "95",
+            "speed": "83",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "243"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/magmortar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/magmortar.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/magmortar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/magmortar.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Togekiss"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Fast",
+            "hp": "85",
+            "attack": "50",
+            "defense": "95",
+            "sp atk": "120",
+            "sp def": "115",
+            "speed": "80",
+            "types": [
+               "Fairy",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "245"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/togekiss.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/togekiss.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/togekiss.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/togekiss.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Yanmega"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Fast",
+            "hp": "86",
+            "attack": "76",
+            "defense": "86",
+            "sp atk": "116",
+            "sp def": "56",
+            "speed": "95",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "180"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/yanmega.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/yanmega.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/yanmega.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/yanmega.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Leafeon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "110",
+            "defense": "130",
+            "sp atk": "60",
+            "sp def": "65",
+            "speed": "95",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "184"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/leafeon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/leafeon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/leafeon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/leafeon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Glaceon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "60",
+            "defense": "110",
+            "sp atk": "130",
+            "sp def": "95",
+            "speed": "65",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "184"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/glaceon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/glaceon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/glaceon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/glaceon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gliscor"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "95",
+            "defense": "125",
+            "sp atk": "45",
+            "sp def": "75",
+            "speed": "95",
+            "types": [
+               "Ground",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "179"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gliscor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gliscor.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gliscor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gliscor.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mamoswine"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "50",
+            "growth rate": "Slow",
+            "hp": "110",
+            "attack": "130",
+            "defense": "80",
+            "sp atk": "70",
+            "sp def": "60",
+            "speed": "80",
+            "types": [
+               "Ice",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "239"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mamoswine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mamoswine.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mamoswine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mamoswine.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Porygon-z"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Fast",
+            "hp": "85",
+            "attack": "80",
+            "defense": "70",
+            "sp atk": "135",
+            "sp def": "75",
+            "speed": "90",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "241"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/porygon-z.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/porygon-z.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/porygon-z.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/porygon-z.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gallade"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "68",
+            "attack": "125",
+            "defense": "65",
+            "sp atk": "65",
+            "sp def": "115",
+            "speed": "80",
+            "types": [
+               "Psychic",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "233"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gallade.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gallade.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gallade.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gallade.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Probopass"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "55",
+            "defense": "145",
+            "sp atk": "75",
+            "sp def": "150",
+            "speed": "40",
+            "types": [
+               "Rock",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "184"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/probopass.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/probopass.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/probopass.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/probopass.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Dusknoir"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "45",
+            "attack": "100",
+            "defense": "135",
+            "sp atk": "65",
+            "sp def": "135",
+            "speed": "45",
+            "types": [
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "236"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dusknoir.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dusknoir.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dusknoir.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dusknoir.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Froslass"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "80",
+            "defense": "70",
+            "sp atk": "80",
+            "sp def": "70",
+            "speed": "110",
+            "types": [
+               "Ice",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/froslass.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/froslass.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/froslass.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/froslass.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Rotom"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "50",
+            "defense": "77",
+            "sp atk": "95",
+            "sp def": "77",
+            "speed": "91",
+            "types": [
+               "Electric",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "154"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rotom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rotom.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/rotom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/rotom.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Uxie"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "75",
+            "attack": "75",
+            "defense": "130",
+            "sp atk": "75",
+            "sp def": "130",
+            "speed": "95",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/uxie.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/uxie.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/uxie.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/uxie.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mesprit"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "105",
+            "defense": "105",
+            "sp atk": "105",
+            "sp def": "105",
+            "speed": "80",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mesprit.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mesprit.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mesprit.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mesprit.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Azelf"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "75",
+            "attack": "125",
+            "defense": "70",
+            "sp atk": "125",
+            "sp def": "70",
+            "speed": "115",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/azelf.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/azelf.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/azelf.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/azelf.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Dialga"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "120",
+            "defense": "120",
+            "sp atk": "150",
+            "sp def": "100",
+            "speed": "90",
+            "types": [
+               "Steel",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "306"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dialga.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dialga.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dialga.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dialga.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Palkia"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Slow",
+            "hp": "90",
+            "attack": "120",
+            "defense": "100",
+            "sp atk": "150",
+            "sp def": "120",
+            "speed": "100",
+            "types": [
+               "Water",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "306"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/palkia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/palkia.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/palkia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/palkia.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Heatran"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "91",
+            "attack": "90",
+            "defense": "106",
+            "sp atk": "130",
+            "sp def": "106",
+            "speed": "77",
+            "types": [
+               "Fire",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/heatran.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/heatran.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/heatran.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/heatran.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Regigigas"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "110",
+            "attack": "160",
+            "defense": "110",
+            "sp atk": "80",
+            "sp def": "110",
+            "speed": "100",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "302"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/regigigas.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/regigigas.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/regigigas.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/regigigas.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Giratina-altered"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "150",
+            "attack": "100",
+            "defense": "120",
+            "sp atk": "100",
+            "sp def": "120",
+            "speed": "90",
+            "types": [
+               "Ghost",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "306"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/giratina-altered.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/giratina-altered.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/giratina-altered.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/giratina-altered.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cresselia"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "120",
+            "attack": "70",
+            "defense": "120",
+            "sp atk": "75",
+            "sp def": "130",
+            "speed": "85",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cresselia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cresselia.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cresselia.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cresselia.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Phione"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "80",
+            "defense": "80",
+            "sp atk": "80",
+            "sp def": "80",
+            "speed": "80",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "216"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/phione.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/phione.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/phione.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/phione.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Manaphy"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "100",
+            "defense": "100",
+            "sp atk": "100",
+            "sp def": "100",
+            "speed": "100",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/manaphy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/manaphy.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/manaphy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/manaphy.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Darkrai"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "90",
+            "defense": "90",
+            "sp atk": "135",
+            "sp def": "90",
+            "speed": "125",
+            "types": [
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/darkrai.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/darkrai.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/darkrai.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/darkrai.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shaymin-land"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "100",
+            "attack": "100",
+            "defense": "100",
+            "sp atk": "100",
+            "sp def": "100",
+            "speed": "100",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shaymin-land.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shaymin-land.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shaymin-land.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shaymin-land.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Arceus"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "120",
+            "attack": "120",
+            "defense": "120",
+            "sp atk": "120",
+            "sp def": "120",
+            "speed": "120",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "324"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/arceus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/arceus.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/arceus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/arceus.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Victini"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "100",
+            "defense": "100",
+            "sp atk": "100",
+            "sp def": "100",
+            "speed": "100",
+            "types": [
+               "Psychic",
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/victini.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/victini.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/victini.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/victini.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Snivy"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "45",
+            "defense": "55",
+            "sp atk": "45",
+            "sp def": "55",
+            "speed": "63",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/snivy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/snivy.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/snivy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/snivy.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Servine"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "60",
+            "defense": "75",
+            "sp atk": "60",
+            "sp def": "75",
+            "speed": "83",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "145"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/servine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/servine.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/servine.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/servine.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Serperior"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "75",
+            "defense": "95",
+            "sp atk": "75",
+            "sp def": "95",
+            "speed": "113",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "238"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/serperior.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/serperior.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/serperior.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/serperior.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tepig"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "65",
+            "attack": "63",
+            "defense": "45",
+            "sp atk": "45",
+            "sp def": "45",
+            "speed": "45",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tepig.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tepig.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tepig.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tepig.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pignite"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "90",
+            "attack": "93",
+            "defense": "55",
+            "sp atk": "70",
+            "sp def": "55",
+            "speed": "55",
+            "types": [
+               "Fire",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "146"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pignite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pignite.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pignite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pignite.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Emboar"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "110",
+            "attack": "123",
+            "defense": "65",
+            "sp atk": "100",
+            "sp def": "65",
+            "speed": "65",
+            "types": [
+               "Fire",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "238"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/emboar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/emboar.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/emboar.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/emboar.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Oshawott"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "55",
+            "attack": "55",
+            "defense": "45",
+            "sp atk": "63",
+            "sp def": "45",
+            "speed": "45",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/oshawott.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/oshawott.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/oshawott.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/oshawott.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Dewott"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "75",
+            "defense": "60",
+            "sp atk": "83",
+            "sp def": "60",
+            "speed": "60",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "145"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dewott.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dewott.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dewott.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dewott.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Samurott"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "95",
+            "attack": "100",
+            "defense": "85",
+            "sp atk": "108",
+            "sp def": "70",
+            "speed": "70",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "238"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/samurott.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/samurott.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/samurott.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/samurott.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Patrat"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "55",
+            "defense": "39",
+            "sp atk": "35",
+            "sp def": "39",
+            "speed": "42",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "51"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/patrat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/patrat.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/patrat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/patrat.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Watchog"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "85",
+            "defense": "69",
+            "sp atk": "60",
+            "sp def": "69",
+            "speed": "77",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "147"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/watchog.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/watchog.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/watchog.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/watchog.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lillipup"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "60",
+            "defense": "45",
+            "sp atk": "25",
+            "sp def": "45",
+            "speed": "55",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "55"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lillipup.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lillipup.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lillipup.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lillipup.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Herdier"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "65",
+            "attack": "80",
+            "defense": "65",
+            "sp atk": "35",
+            "sp def": "65",
+            "speed": "60",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "130"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/herdier.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/herdier.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/herdier.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/herdier.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Stoutland"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "85",
+            "attack": "110",
+            "defense": "90",
+            "sp atk": "45",
+            "sp def": "90",
+            "speed": "80",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "225"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/stoutland.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/stoutland.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/stoutland.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/stoutland.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Purrloin"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "41",
+            "attack": "50",
+            "defense": "37",
+            "sp atk": "50",
+            "sp def": "37",
+            "speed": "66",
+            "types": [
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "56"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/purrloin.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/purrloin.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/purrloin.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/purrloin.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Liepard"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "64",
+            "attack": "88",
+            "defense": "50",
+            "sp atk": "88",
+            "sp def": "50",
+            "speed": "106",
+            "types": [
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "156"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/liepard.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/liepard.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/liepard.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/liepard.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pansage"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "53",
+            "defense": "48",
+            "sp atk": "53",
+            "sp def": "48",
+            "speed": "64",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "63"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pansage.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pansage.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pansage.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pansage.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Simisage"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "98",
+            "defense": "63",
+            "sp atk": "98",
+            "sp def": "63",
+            "speed": "101",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "174"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/simisage.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/simisage.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/simisage.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/simisage.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pansear"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "53",
+            "defense": "48",
+            "sp atk": "53",
+            "sp def": "48",
+            "speed": "64",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "63"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pansear.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pansear.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pansear.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pansear.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Simisear"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "98",
+            "defense": "63",
+            "sp atk": "98",
+            "sp def": "63",
+            "speed": "101",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "174"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/simisear.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/simisear.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/simisear.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/simisear.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Panpour"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "53",
+            "defense": "48",
+            "sp atk": "53",
+            "sp def": "48",
+            "speed": "64",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "63"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/panpour.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/panpour.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/panpour.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/panpour.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Simipour"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "98",
+            "defense": "63",
+            "sp atk": "98",
+            "sp def": "63",
+            "speed": "101",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "174"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/simipour.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/simipour.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/simipour.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/simipour.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Munna"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Fast",
+            "hp": "76",
+            "attack": "25",
+            "defense": "45",
+            "sp atk": "67",
+            "sp def": "55",
+            "speed": "24",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/munna.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/munna.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/munna.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/munna.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Musharna"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Fast",
+            "hp": "116",
+            "attack": "55",
+            "defense": "85",
+            "sp atk": "107",
+            "sp def": "95",
+            "speed": "29",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "170"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/musharna.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/musharna.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/musharna.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/musharna.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pidove"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "55",
+            "defense": "50",
+            "sp atk": "36",
+            "sp def": "30",
+            "speed": "43",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "53"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pidove.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pidove.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pidove.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pidove.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tranquill"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "62",
+            "attack": "77",
+            "defense": "62",
+            "sp atk": "50",
+            "sp def": "42",
+            "speed": "65",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "125"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tranquill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tranquill.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tranquill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tranquill.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Unfezant"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "80",
+            "attack": "115",
+            "defense": "80",
+            "sp atk": "65",
+            "sp def": "55",
+            "speed": "93",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "220"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/unfezant.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/unfezant.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/unfezant.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/unfezant.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Blitzle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "60",
+            "defense": "32",
+            "sp atk": "50",
+            "sp def": "32",
+            "speed": "76",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "59"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/blitzle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/blitzle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/blitzle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/blitzle.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Zebstrika"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "100",
+            "defense": "63",
+            "sp atk": "80",
+            "sp def": "63",
+            "speed": "116",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "174"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zebstrika.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zebstrika.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/zebstrika.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/zebstrika.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Roggenrola"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "55",
+            "attack": "75",
+            "defense": "85",
+            "sp atk": "25",
+            "sp def": "25",
+            "speed": "15",
+            "types": [
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "56"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/roggenrola.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/roggenrola.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/roggenrola.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/roggenrola.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Boldore"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "105",
+            "defense": "105",
+            "sp atk": "50",
+            "sp def": "40",
+            "speed": "20",
+            "types": [
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "137"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/boldore.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/boldore.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/boldore.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/boldore.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gigalith"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "85",
+            "attack": "135",
+            "defense": "130",
+            "sp atk": "60",
+            "sp def": "80",
+            "speed": "25",
+            "types": [
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "232"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gigalith.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gigalith.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gigalith.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gigalith.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Woobat"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "55",
+            "attack": "45",
+            "defense": "43",
+            "sp atk": "55",
+            "sp def": "43",
+            "speed": "72",
+            "types": [
+               "Psychic",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "63"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/woobat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/woobat.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/woobat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/woobat.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Swoobat"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "67",
+            "attack": "57",
+            "defense": "55",
+            "sp atk": "77",
+            "sp def": "55",
+            "speed": "114",
+            "types": [
+               "Psychic",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "149"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/swoobat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/swoobat.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/swoobat.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/swoobat.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Drilbur"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "85",
+            "defense": "40",
+            "sp atk": "30",
+            "sp def": "45",
+            "speed": "68",
+            "types": [
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/drilbur.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/drilbur.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/drilbur.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/drilbur.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Excadrill"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "110",
+            "attack": "135",
+            "defense": "60",
+            "sp atk": "50",
+            "sp def": "65",
+            "speed": "88",
+            "types": [
+               "Ground",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "178"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/excadrill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/excadrill.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/excadrill.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/excadrill.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Audino"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Fast",
+            "hp": "103",
+            "attack": "60",
+            "defense": "86",
+            "sp atk": "60",
+            "sp def": "86",
+            "speed": "50",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "390"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/audino.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/audino.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/audino.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/audino.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Timburr"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "180",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "80",
+            "defense": "55",
+            "sp atk": "25",
+            "sp def": "35",
+            "speed": "35",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/timburr.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/timburr.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/timburr.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/timburr.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gurdurr"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Slow",
+            "hp": "85",
+            "attack": "105",
+            "defense": "85",
+            "sp atk": "40",
+            "sp def": "50",
+            "speed": "40",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gurdurr.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gurdurr.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gurdurr.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gurdurr.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Conkeldurr"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "105",
+            "attack": "140",
+            "defense": "95",
+            "sp atk": "55",
+            "sp def": "65",
+            "speed": "45",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "227"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/conkeldurr.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/conkeldurr.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/conkeldurr.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/conkeldurr.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tympole"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "50",
+            "defense": "40",
+            "sp atk": "50",
+            "sp def": "40",
+            "speed": "64",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "59"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tympole.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tympole.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tympole.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tympole.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Palpitoad"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "65",
+            "defense": "55",
+            "sp atk": "65",
+            "sp def": "55",
+            "speed": "69",
+            "types": [
+               "Water",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "134"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/palpitoad.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/palpitoad.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/palpitoad.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/palpitoad.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Seismitoad"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "105",
+            "attack": "95",
+            "defense": "75",
+            "sp atk": "85",
+            "sp def": "75",
+            "speed": "74",
+            "types": [
+               "Water",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "229"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/seismitoad.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/seismitoad.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/seismitoad.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/seismitoad.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Throh"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "120",
+            "attack": "100",
+            "defense": "85",
+            "sp atk": "30",
+            "sp def": "85",
+            "speed": "45",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "163"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/throh.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/throh.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/throh.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/throh.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sawk"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "125",
+            "defense": "75",
+            "sp atk": "30",
+            "sp def": "75",
+            "speed": "85",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "163"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sawk.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sawk.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sawk.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sawk.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sewaddle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "53",
+            "defense": "70",
+            "sp atk": "40",
+            "sp def": "60",
+            "speed": "42",
+            "types": [
+               "Bug",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sewaddle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sewaddle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sewaddle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sewaddle.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Swadloon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "55",
+            "attack": "63",
+            "defense": "90",
+            "sp atk": "50",
+            "sp def": "80",
+            "speed": "42",
+            "types": [
+               "Bug",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "133"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/swadloon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/swadloon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/swadloon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/swadloon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Leavanny"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "103",
+            "defense": "80",
+            "sp atk": "70",
+            "sp def": "80",
+            "speed": "92",
+            "types": [
+               "Bug",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "225"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/leavanny.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/leavanny.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/leavanny.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/leavanny.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Venipede"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "30",
+            "attack": "45",
+            "defense": "59",
+            "sp atk": "30",
+            "sp def": "39",
+            "speed": "57",
+            "types": [
+               "Bug",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "52"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/venipede.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/venipede.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/venipede.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/venipede.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Whirlipede"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "55",
+            "defense": "99",
+            "sp atk": "40",
+            "sp def": "79",
+            "speed": "47",
+            "types": [
+               "Bug",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "126"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/whirlipede.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/whirlipede.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/whirlipede.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/whirlipede.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Scolipede"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "100",
+            "defense": "89",
+            "sp atk": "55",
+            "sp def": "69",
+            "speed": "112",
+            "types": [
+               "Bug",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "218"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/scolipede.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/scolipede.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/scolipede.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/scolipede.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cottonee"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "40",
+            "attack": "27",
+            "defense": "60",
+            "sp atk": "37",
+            "sp def": "50",
+            "speed": "66",
+            "types": [
+               "Grass",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "56"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cottonee.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cottonee.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cottonee.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cottonee.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Whimsicott"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "67",
+            "defense": "85",
+            "sp atk": "77",
+            "sp def": "75",
+            "speed": "116",
+            "types": [
+               "Grass",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/whimsicott.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/whimsicott.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/whimsicott.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/whimsicott.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Petilil"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "35",
+            "defense": "50",
+            "sp atk": "70",
+            "sp def": "50",
+            "speed": "30",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "56"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/petilil.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/petilil.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/petilil.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/petilil.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lilligant"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "60",
+            "defense": "75",
+            "sp atk": "110",
+            "sp def": "75",
+            "speed": "90",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lilligant.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lilligant.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lilligant.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lilligant.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Basculin-red-striped"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "25",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "92",
+            "defense": "65",
+            "sp atk": "80",
+            "sp def": "55",
+            "speed": "98",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "161"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/basculin-red-striped.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/basculin-red-striped.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/basculin-red-striped.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/basculin-red-striped.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sandile"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "180",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "72",
+            "defense": "35",
+            "sp atk": "35",
+            "sp def": "35",
+            "speed": "65",
+            "types": [
+               "Ground",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sandile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sandile.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sandile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sandile.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Krokorok"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "82",
+            "defense": "45",
+            "sp atk": "45",
+            "sp def": "45",
+            "speed": "74",
+            "types": [
+               "Ground",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "123"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/krokorok.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/krokorok.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/krokorok.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/krokorok.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Krookodile"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "95",
+            "attack": "117",
+            "defense": "80",
+            "sp atk": "65",
+            "sp def": "70",
+            "speed": "92",
+            "types": [
+               "Ground",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "234"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/krookodile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/krookodile.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/krookodile.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/krookodile.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Darumaka"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "90",
+            "defense": "45",
+            "sp atk": "15",
+            "sp def": "45",
+            "speed": "50",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "63"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/darumaka.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/darumaka.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/darumaka.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/darumaka.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Darmanitan-standard"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Slow",
+            "hp": "105",
+            "attack": "140",
+            "defense": "55",
+            "sp atk": "30",
+            "sp def": "55",
+            "speed": "95",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/darmanitan-standard-mode.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/darmanitan-standard-mode.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/darmanitan-standard-mode.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/darmanitan-standard-mode.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Maractus"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "86",
+            "defense": "67",
+            "sp atk": "106",
+            "sp def": "67",
+            "speed": "60",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "161"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/maractus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/maractus.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/maractus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/maractus.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Dwebble"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "65",
+            "defense": "85",
+            "sp atk": "35",
+            "sp def": "35",
+            "speed": "55",
+            "types": [
+               "Bug",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "65"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/dwebble.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/dwebble.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/dwebble.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/dwebble.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Crustle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "95",
+            "defense": "125",
+            "sp atk": "65",
+            "sp def": "75",
+            "speed": "45",
+            "types": [
+               "Bug",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "166"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/crustle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/crustle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/crustle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/crustle.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Scraggy"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "180",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "75",
+            "defense": "70",
+            "sp atk": "35",
+            "sp def": "70",
+            "speed": "48",
+            "types": [
+               "Dark",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "70"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/scraggy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/scraggy.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/scraggy.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/scraggy.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Scrafty"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "90",
+            "defense": "115",
+            "sp atk": "45",
+            "sp def": "115",
+            "speed": "58",
+            "types": [
+               "Dark",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "171"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/scrafty.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/scrafty.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/scrafty.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/scrafty.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sigilyph"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "72",
+            "attack": "58",
+            "defense": "80",
+            "sp atk": "103",
+            "sp def": "80",
+            "speed": "97",
+            "types": [
+               "Psychic",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "172"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sigilyph.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sigilyph.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sigilyph.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sigilyph.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Yamask"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "38",
+            "attack": "30",
+            "defense": "85",
+            "sp atk": "55",
+            "sp def": "65",
+            "speed": "30",
+            "types": [
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/yamask.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/yamask.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/yamask.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/yamask.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cofagrigus"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "58",
+            "attack": "50",
+            "defense": "145",
+            "sp atk": "95",
+            "sp def": "105",
+            "speed": "30",
+            "types": [
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "169"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cofagrigus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cofagrigus.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cofagrigus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cofagrigus.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tirtouga"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "54",
+            "attack": "78",
+            "defense": "103",
+            "sp atk": "53",
+            "sp def": "45",
+            "speed": "22",
+            "types": [
+               "Water",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "71"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tirtouga.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tirtouga.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tirtouga.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tirtouga.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Carracosta"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "74",
+            "attack": "108",
+            "defense": "133",
+            "sp atk": "83",
+            "sp def": "65",
+            "speed": "32",
+            "types": [
+               "Water",
+               "Rock"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/carracosta.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/carracosta.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/carracosta.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/carracosta.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Archen"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "55",
+            "attack": "112",
+            "defense": "45",
+            "sp atk": "74",
+            "sp def": "45",
+            "speed": "70",
+            "types": [
+               "Rock",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "71"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/archen.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/archen.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/archen.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/archen.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Archeops"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "140",
+            "defense": "65",
+            "sp atk": "112",
+            "sp def": "65",
+            "speed": "110",
+            "types": [
+               "Rock",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "177"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/archeops.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/archeops.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/archeops.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/archeops.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Trubbish"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "50",
+            "defense": "62",
+            "sp atk": "40",
+            "sp def": "62",
+            "speed": "65",
+            "types": [
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/trubbish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/trubbish.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/trubbish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/trubbish.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Garbodor"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "80",
+            "attack": "95",
+            "defense": "82",
+            "sp atk": "60",
+            "sp def": "82",
+            "speed": "75",
+            "types": [
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "166"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/garbodor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/garbodor.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/garbodor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/garbodor.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Zorua"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "65",
+            "defense": "40",
+            "sp atk": "80",
+            "sp def": "40",
+            "speed": "65",
+            "types": [
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zorua.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zorua.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/zorua.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/zorua.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Zoroark"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "105",
+            "defense": "60",
+            "sp atk": "120",
+            "sp def": "60",
+            "speed": "105",
+            "types": [
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "179"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zoroark.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zoroark.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/zoroark.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/zoroark.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Minccino"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Fast",
+            "hp": "55",
+            "attack": "50",
+            "defense": "40",
+            "sp atk": "40",
+            "sp def": "40",
+            "speed": "75",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/minccino.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/minccino.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/minccino.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/minccino.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cinccino"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Fast",
+            "hp": "75",
+            "attack": "95",
+            "defense": "60",
+            "sp atk": "65",
+            "sp def": "60",
+            "speed": "115",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "165"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cinccino.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cinccino.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cinccino.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cinccino.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gothita"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "30",
+            "defense": "50",
+            "sp atk": "55",
+            "sp def": "65",
+            "speed": "45",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gothita.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gothita.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gothita.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gothita.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gothorita"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "100",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "45",
+            "defense": "70",
+            "sp atk": "75",
+            "sp def": "85",
+            "speed": "55",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "137"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gothorita.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gothorita.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gothorita.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gothorita.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gothitelle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "50",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "55",
+            "defense": "95",
+            "sp atk": "95",
+            "sp def": "110",
+            "speed": "65",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "221"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/gothitelle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/gothitelle.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/gothitelle.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/gothitelle.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Solosis"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "30",
+            "defense": "40",
+            "sp atk": "105",
+            "sp def": "50",
+            "speed": "20",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/solosis.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/solosis.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/solosis.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/solosis.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Duosion"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "100",
+            "growth rate": "Medium Slow",
+            "hp": "65",
+            "attack": "40",
+            "defense": "50",
+            "sp atk": "125",
+            "sp def": "60",
+            "speed": "30",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "130"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/duosion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/duosion.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/duosion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/duosion.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Reuniclus"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "50",
+            "growth rate": "Medium Slow",
+            "hp": "110",
+            "attack": "65",
+            "defense": "75",
+            "sp atk": "125",
+            "sp def": "85",
+            "speed": "30",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "221"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/reuniclus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/reuniclus.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/reuniclus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/reuniclus.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ducklett"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "62",
+            "attack": "44",
+            "defense": "50",
+            "sp atk": "44",
+            "sp def": "50",
+            "speed": "55",
+            "types": [
+               "Water",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ducklett.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ducklett.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ducklett.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ducklett.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Swanna"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "87",
+            "defense": "63",
+            "sp atk": "87",
+            "sp def": "63",
+            "speed": "98",
+            "types": [
+               "Water",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "166"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/swanna.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/swanna.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/swanna.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/swanna.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Vanillite"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Slow",
+            "hp": "36",
+            "attack": "50",
+            "defense": "50",
+            "sp atk": "65",
+            "sp def": "60",
+            "speed": "44",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vanillite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vanillite.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/vanillite.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/vanillite.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Vanillish"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Slow",
+            "hp": "51",
+            "attack": "65",
+            "defense": "65",
+            "sp atk": "80",
+            "sp def": "75",
+            "speed": "59",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "138"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vanillish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vanillish.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/vanillish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/vanillish.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Vanilluxe"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "71",
+            "attack": "95",
+            "defense": "85",
+            "sp atk": "110",
+            "sp def": "95",
+            "speed": "79",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "241"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vanilluxe.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vanilluxe.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/vanilluxe.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/vanilluxe.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Deerling"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "60",
+            "defense": "50",
+            "sp atk": "40",
+            "sp def": "50",
+            "speed": "75",
+            "types": [
+               "Normal",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "67"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/deerling.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/deerling.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/deerling.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/deerling.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sawsbuck"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "80",
+            "attack": "100",
+            "defense": "70",
+            "sp atk": "60",
+            "sp def": "70",
+            "speed": "95",
+            "types": [
+               "Normal",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "166"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/sawsbuck.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/sawsbuck.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/sawsbuck.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/sawsbuck.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Emolga"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Fast",
+            "hp": "55",
+            "attack": "75",
+            "defense": "60",
+            "sp atk": "75",
+            "sp def": "60",
+            "speed": "103",
+            "types": [
+               "Electric",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "150"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/emolga.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/emolga.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/emolga.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/emolga.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Karrablast"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "75",
+            "defense": "45",
+            "sp atk": "40",
+            "sp def": "45",
+            "speed": "60",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "63"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/karrablast.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/karrablast.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/karrablast.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/karrablast.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Escavalier"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "135",
+            "defense": "105",
+            "sp atk": "60",
+            "sp def": "105",
+            "speed": "20",
+            "types": [
+               "Bug",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/escavalier.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/escavalier.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/escavalier.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/escavalier.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Foongus"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "69",
+            "attack": "55",
+            "defense": "45",
+            "sp atk": "55",
+            "sp def": "55",
+            "speed": "15",
+            "types": [
+               "Grass",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "59"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/foongus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/foongus.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/foongus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/foongus.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Amoonguss"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "114",
+            "attack": "85",
+            "defense": "70",
+            "sp atk": "85",
+            "sp def": "80",
+            "speed": "30",
+            "types": [
+               "Grass",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "162"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/amoonguss.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/amoonguss.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/amoonguss.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/amoonguss.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Frillish"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "55",
+            "attack": "40",
+            "defense": "50",
+            "sp atk": "65",
+            "sp def": "85",
+            "speed": "40",
+            "types": [
+               "Water",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "67"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/frillish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/frillish.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/frillish.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/frillish.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Jellicent"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "100",
+            "attack": "60",
+            "defense": "70",
+            "sp atk": "85",
+            "sp def": "105",
+            "speed": "60",
+            "types": [
+               "Water",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/jellicent.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/jellicent.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/jellicent.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/jellicent.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Alomomola"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Fast",
+            "hp": "165",
+            "attack": "75",
+            "defense": "80",
+            "sp atk": "40",
+            "sp def": "45",
+            "speed": "65",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "165"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/alomomola.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/alomomola.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/alomomola.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/alomomola.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Joltik"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "47",
+            "defense": "50",
+            "sp atk": "57",
+            "sp def": "50",
+            "speed": "65",
+            "types": [
+               "Bug",
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "64"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/joltik.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/joltik.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/joltik.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/joltik.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Galvantula"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "77",
+            "defense": "60",
+            "sp atk": "97",
+            "sp def": "60",
+            "speed": "108",
+            "types": [
+               "Bug",
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "165"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/galvantula.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/galvantula.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/galvantula.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/galvantula.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ferroseed"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "44",
+            "attack": "50",
+            "defense": "91",
+            "sp atk": "24",
+            "sp def": "86",
+            "speed": "10",
+            "types": [
+               "Grass",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ferroseed.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ferroseed.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ferroseed.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ferroseed.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Ferrothorn"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "74",
+            "attack": "94",
+            "defense": "131",
+            "sp atk": "54",
+            "sp def": "116",
+            "speed": "20",
+            "types": [
+               "Grass",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "171"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/ferrothorn.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/ferrothorn.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/ferrothorn.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/ferrothorn.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Klink"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "130",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "55",
+            "defense": "70",
+            "sp atk": "45",
+            "sp def": "60",
+            "speed": "30",
+            "types": [
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/klink.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/klink.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/klink.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/klink.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Klang"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "80",
+            "defense": "95",
+            "sp atk": "70",
+            "sp def": "85",
+            "speed": "50",
+            "types": [
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "154"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/klang.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/klang.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/klang.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/klang.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Klinklang"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "100",
+            "defense": "115",
+            "sp atk": "70",
+            "sp def": "85",
+            "speed": "90",
+            "types": [
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "234"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/klinklang.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/klinklang.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/klinklang.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/klinklang.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tynamo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Slow",
+            "hp": "35",
+            "attack": "55",
+            "defense": "40",
+            "sp atk": "45",
+            "sp def": "40",
+            "speed": "60",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "55"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tynamo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tynamo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tynamo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tynamo.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Eelektrik"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow",
+            "hp": "65",
+            "attack": "85",
+            "defense": "70",
+            "sp atk": "75",
+            "sp def": "70",
+            "speed": "40",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/eelektrik.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/eelektrik.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/eelektrik.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/eelektrik.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Eelektross"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Slow",
+            "hp": "85",
+            "attack": "115",
+            "defense": "80",
+            "sp atk": "105",
+            "sp def": "80",
+            "speed": "50",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "232"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/eelektross.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/eelektross.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/eelektross.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/eelektross.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Elgyem"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "55",
+            "attack": "55",
+            "defense": "55",
+            "sp atk": "85",
+            "sp def": "55",
+            "speed": "30",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "67"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/elgyem.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/elgyem.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/elgyem.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/elgyem.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Beheeyem"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "75",
+            "defense": "75",
+            "sp atk": "125",
+            "sp def": "95",
+            "speed": "40",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "170"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/beheeyem.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/beheeyem.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/beheeyem.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/beheeyem.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Litwick"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "30",
+            "defense": "55",
+            "sp atk": "65",
+            "sp def": "55",
+            "speed": "20",
+            "types": [
+               "Ghost",
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "55"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/litwick.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/litwick.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/litwick.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/litwick.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Lampent"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "40",
+            "defense": "60",
+            "sp atk": "95",
+            "sp def": "60",
+            "speed": "55",
+            "types": [
+               "Ghost",
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "130"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/lampent.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/lampent.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/lampent.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/lampent.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Chandelure"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "60",
+            "attack": "55",
+            "defense": "90",
+            "sp atk": "145",
+            "sp def": "90",
+            "speed": "80",
+            "types": [
+               "Ghost",
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "234"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/chandelure.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/chandelure.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/chandelure.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/chandelure.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Axew"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Slow",
+            "hp": "46",
+            "attack": "87",
+            "defense": "60",
+            "sp atk": "30",
+            "sp def": "40",
+            "speed": "57",
+            "types": [
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "64"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/axew.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/axew.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/axew.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/axew.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Fraxure"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow",
+            "hp": "66",
+            "attack": "117",
+            "defense": "70",
+            "sp atk": "40",
+            "sp def": "50",
+            "speed": "67",
+            "types": [
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "144"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/fraxure.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/fraxure.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/fraxure.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/fraxure.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Haxorus"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "76",
+            "attack": "147",
+            "defense": "90",
+            "sp atk": "60",
+            "sp def": "70",
+            "speed": "97",
+            "types": [
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "243"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/haxorus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/haxorus.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/haxorus.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/haxorus.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cubchoo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "55",
+            "attack": "70",
+            "defense": "40",
+            "sp atk": "60",
+            "sp def": "40",
+            "speed": "40",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cubchoo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cubchoo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cubchoo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cubchoo.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Beartic"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "95",
+            "attack": "110",
+            "defense": "80",
+            "sp atk": "70",
+            "sp def": "80",
+            "speed": "50",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "170"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/beartic.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/beartic.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/beartic.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/beartic.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cryogonal"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "25",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "50",
+            "defense": "30",
+            "sp atk": "95",
+            "sp def": "135",
+            "speed": "105",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "170"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cryogonal.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cryogonal.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cryogonal.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cryogonal.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Shelmet"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "40",
+            "defense": "85",
+            "sp atk": "40",
+            "sp def": "65",
+            "speed": "25",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/shelmet.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/shelmet.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/shelmet.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/shelmet.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Accelgor"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "80",
+            "attack": "70",
+            "defense": "40",
+            "sp atk": "100",
+            "sp def": "60",
+            "speed": "145",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/accelgor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/accelgor.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/accelgor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/accelgor.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Stunfisk"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "109",
+            "attack": "66",
+            "defense": "84",
+            "sp atk": "81",
+            "sp def": "99",
+            "speed": "32",
+            "types": [
+               "Ground",
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "165"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/stunfisk.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/stunfisk.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/stunfisk.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/stunfisk.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mienfoo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "180",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "85",
+            "defense": "50",
+            "sp atk": "55",
+            "sp def": "50",
+            "speed": "65",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "70"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mienfoo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mienfoo.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mienfoo.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mienfoo.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mienshao"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "65",
+            "attack": "125",
+            "defense": "60",
+            "sp atk": "95",
+            "sp def": "60",
+            "speed": "105",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "179"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mienshao.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mienshao.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mienshao.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mienshao.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Druddigon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "77",
+            "attack": "120",
+            "defense": "90",
+            "sp atk": "60",
+            "sp def": "90",
+            "speed": "48",
+            "types": [
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "170"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/druddigon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/druddigon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/druddigon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/druddigon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Golett"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "59",
+            "attack": "74",
+            "defense": "50",
+            "sp atk": "35",
+            "sp def": "50",
+            "speed": "35",
+            "types": [
+               "Ground",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/golett.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/golett.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/golett.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/golett.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Golurk"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "89",
+            "attack": "124",
+            "defense": "80",
+            "sp atk": "55",
+            "sp def": "80",
+            "speed": "55",
+            "types": [
+               "Ground",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "169"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/golurk.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/golurk.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/golurk.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/golurk.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pawniard"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "85",
+            "defense": "70",
+            "sp atk": "40",
+            "sp def": "40",
+            "speed": "60",
+            "types": [
+               "Dark",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "68"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/pawniard.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/pawniard.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/pawniard.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/pawniard.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bisharp"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "125",
+            "defense": "100",
+            "sp atk": "60",
+            "sp def": "70",
+            "speed": "70",
+            "types": [
+               "Dark",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "172"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bisharp.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bisharp.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bisharp.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bisharp.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bouffalant"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "95",
+            "attack": "110",
+            "defense": "95",
+            "sp atk": "40",
+            "sp def": "95",
+            "speed": "55",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "172"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/bouffalant.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/bouffalant.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/bouffalant.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/bouffalant.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Rufflet"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "83",
+            "defense": "50",
+            "sp atk": "37",
+            "sp def": "50",
+            "speed": "60",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "70"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/rufflet.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/rufflet.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/rufflet.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/rufflet.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Braviary"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "123",
+            "defense": "75",
+            "sp atk": "57",
+            "sp def": "75",
+            "speed": "80",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "179"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/braviary.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/braviary.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/braviary.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/braviary.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Vullaby"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "55",
+            "defense": "75",
+            "sp atk": "45",
+            "sp def": "65",
+            "speed": "60",
+            "types": [
+               "Dark",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "74"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/vullaby.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/vullaby.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/vullaby.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/vullaby.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Mandibuzz"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow",
+            "hp": "110",
+            "attack": "65",
+            "defense": "105",
+            "sp atk": "55",
+            "sp def": "95",
+            "speed": "80",
+            "types": [
+               "Dark",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "179"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/mandibuzz.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/mandibuzz.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/mandibuzz.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/mandibuzz.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Heatmor"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "85",
+            "attack": "97",
+            "defense": "66",
+            "sp atk": "105",
+            "sp def": "66",
+            "speed": "65",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "169"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/heatmor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/heatmor.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/heatmor.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/heatmor.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Durant"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "58",
+            "attack": "109",
+            "defense": "112",
+            "sp atk": "48",
+            "sp def": "48",
+            "speed": "109",
+            "types": [
+               "Bug",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "169"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/durant.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/durant.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/durant.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/durant.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Deino"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "52",
+            "attack": "65",
+            "defense": "50",
+            "sp atk": "45",
+            "sp def": "50",
+            "speed": "38",
+            "types": [
+               "Dark",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/deino.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/deino.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/deino.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/deino.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Zweilous"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "72",
+            "attack": "85",
+            "defense": "70",
+            "sp atk": "65",
+            "sp def": "70",
+            "speed": "58",
+            "types": [
+               "Dark",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "147"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zweilous.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zweilous.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/zweilous.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/zweilous.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Hydreigon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "92",
+            "attack": "105",
+            "defense": "90",
+            "sp atk": "125",
+            "sp def": "90",
+            "speed": "98",
+            "types": [
+               "Dark",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/hydreigon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/hydreigon.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/hydreigon.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/hydreigon.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Larvesta"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "55",
+            "attack": "85",
+            "defense": "55",
+            "sp atk": "50",
+            "sp def": "55",
+            "speed": "60",
+            "types": [
+               "Bug",
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "72"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/larvesta.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/larvesta.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/larvesta.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/larvesta.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Volcarona"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "15",
+            "growth rate": "Slow",
+            "hp": "85",
+            "attack": "60",
+            "defense": "65",
+            "sp atk": "135",
+            "sp def": "105",
+            "speed": "100",
+            "types": [
+               "Bug",
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "248"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/volcarona.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/volcarona.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/volcarona.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/volcarona.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Cobalion"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "91",
+            "attack": "90",
+            "defense": "129",
+            "sp atk": "90",
+            "sp def": "72",
+            "speed": "108",
+            "types": [
+               "Steel",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/cobalion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/cobalion.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/cobalion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/cobalion.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Terrakion"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "91",
+            "attack": "129",
+            "defense": "90",
+            "sp atk": "72",
+            "sp def": "90",
+            "speed": "108",
+            "types": [
+               "Rock",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/terrakion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/terrakion.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/terrakion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/terrakion.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Virizion"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "91",
+            "attack": "90",
+            "defense": "72",
+            "sp atk": "90",
+            "sp def": "129",
+            "speed": "108",
+            "types": [
+               "Grass",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/virizion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/virizion.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/virizion.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/virizion.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tornadus-incarnate"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "79",
+            "attack": "115",
+            "defense": "70",
+            "sp atk": "125",
+            "sp def": "80",
+            "speed": "111",
+            "types": [
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/tornadus-incarnate.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/tornadus-incarnate.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/tornadus-incarnate.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/tornadus-incarnate.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Thundurus-incarnate"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "79",
+            "attack": "115",
+            "defense": "70",
+            "sp atk": "125",
+            "sp def": "80",
+            "speed": "111",
+            "types": [
+               "Electric",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/thundurus-incarnate.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/thundurus-incarnate.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/thundurus-incarnate.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/thundurus-incarnate.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Reshiram"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "120",
+            "defense": "100",
+            "sp atk": "150",
+            "sp def": "120",
+            "speed": "90",
+            "types": [
+               "Dragon",
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "306"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/reshiram.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/reshiram.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/reshiram.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/reshiram.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Zekrom"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "150",
+            "defense": "120",
+            "sp atk": "120",
+            "sp def": "100",
+            "speed": "90",
+            "types": [
+               "Dragon",
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "306"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/zekrom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/zekrom.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/zekrom.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/zekrom.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Landorus-incarnate"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "89",
+            "attack": "125",
+            "defense": "90",
+            "sp atk": "115",
+            "sp def": "80",
+            "speed": "101",
+            "types": [
+               "Ground",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/landorus-incarnate.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/landorus-incarnate.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/landorus-incarnate.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/landorus-incarnate.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Kyurem"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "125",
+            "attack": "130",
+            "defense": "90",
+            "sp atk": "130",
+            "sp def": "90",
+            "speed": "95",
+            "types": [
+               "Dragon",
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "297"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/kyurem.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/kyurem.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/kyurem.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/kyurem.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Keldeo-ordinary"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "91",
+            "attack": "72",
+            "defense": "90",
+            "sp atk": "129",
+            "sp def": "90",
+            "speed": "108",
+            "types": [
+               "Water",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/keldeo-ordinary.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/keldeo-ordinary.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/keldeo-ordinary.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/keldeo-ordinary.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Meloetta-aria"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "77",
+            "defense": "77",
+            "sp atk": "128",
+            "sp def": "128",
+            "speed": "90",
+            "types": [
+               "Normal",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/meloetta-aria.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/meloetta-aria.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/meloetta-aria.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/meloetta-aria.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Genesect"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "71",
+            "attack": "120",
+            "defense": "95",
+            "sp atk": "120",
+            "sp def": "95",
+            "speed": "99",
+            "types": [
+               "Bug",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/normal/genesect.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-normal/genesect.gif"
+         },
+         "shiny": {
+            "front": "https://img.pokemondb.net/sprites/black-white/anim/shiny/genesect.gif",
+            "back": "https://img.pokemondb.net/sprites/black-white/anim/back-shiny/genesect.gif"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Chespin"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "56",
+            "attack": "61",
+            "defense": "65",
+            "sp atk": "48",
+            "sp def": "45",
+            "speed": "38",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "63"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/650.png",
+            "back": "sprites/back/650.png"
+         },
+         "shiny": {
+            "front": "sprites/s650.png",
+            "back": "sprites/back/s650.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Quilladin"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "61",
+            "attack": "78",
+            "defense": "95",
+            "sp atk": "56",
+            "sp def": "58",
+            "speed": "57",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/651.png",
+            "back": "sprites/back/651.png"
+         },
+         "shiny": {
+            "front": "sprites/s651.png",
+            "back": "sprites/back/s651.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Chesnaught"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "88",
+            "attack": "107",
+            "defense": "122",
+            "sp atk": "74",
+            "sp def": "75",
+            "speed": "64",
+            "types": [
+               "Grass",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "239"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/652.png",
+            "back": "sprites/back/652.png"
+         },
+         "shiny": {
+            "front": "sprites/s652.png",
+            "back": "sprites/back/s652.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Fennekin"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "40",
+            "attack": "45",
+            "defense": "40",
+            "sp atk": "62",
+            "sp def": "60",
+            "speed": "60",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/653.png",
+            "back": "sprites/back/653.png"
+         },
+         "shiny": {
+            "front": "sprites/s653.png",
+            "back": "sprites/back/s653.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Braixen"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "59",
+            "attack": "59",
+            "defense": "58",
+            "sp atk": "90",
+            "sp def": "70",
+            "speed": "73",
+            "types": [
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "143"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/654.png",
+            "back": "sprites/back/654.png"
+         },
+         "shiny": {
+            "front": "sprites/s654.png",
+            "back": "sprites/back/s654.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Delphox"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "75",
+            "attack": "69",
+            "defense": "72",
+            "sp atk": "114",
+            "sp def": "100",
+            "speed": "104",
+            "types": [
+               "Fire",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "240"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/655.png",
+            "back": "sprites/back/655.png"
+         },
+         "shiny": {
+            "front": "sprites/s655.png",
+            "back": "sprites/back/s655.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Froakie"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "41",
+            "attack": "56",
+            "defense": "40",
+            "sp atk": "62",
+            "sp def": "44",
+            "speed": "71",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "63"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/656.png",
+            "back": "sprites/back/656.png"
+         },
+         "shiny": {
+            "front": "sprites/s656.png",
+            "back": "sprites/back/s656.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Frogadier"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "54",
+            "attack": "63",
+            "defense": "52",
+            "sp atk": "83",
+            "sp def": "56",
+            "speed": "97",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "142"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/657.png",
+            "back": "sprites/back/657.png"
+         },
+         "shiny": {
+            "front": "sprites/s657.png",
+            "back": "sprites/back/s657.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Greninja"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "72",
+            "attack": "95",
+            "defense": "67",
+            "sp atk": "103",
+            "sp def": "71",
+            "speed": "122",
+            "types": [
+               "Water",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "239"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/658.png",
+            "back": "sprites/back/658.png"
+         },
+         "shiny": {
+            "front": "sprites/s658.png",
+            "back": "sprites/back/s658.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bunnelby"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "38",
+            "attack": "36",
+            "defense": "38",
+            "sp atk": "32",
+            "sp def": "36",
+            "speed": "57",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "47"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/659.png",
+            "back": "sprites/back/659.png"
+         },
+         "shiny": {
+            "front": "sprites/s659.png",
+            "back": "sprites/back/s659.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Diggersby"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "127",
+            "growth rate": "Medium Fast",
+            "hp": "85",
+            "attack": "56",
+            "defense": "77",
+            "sp atk": "50",
+            "sp def": "77",
+            "speed": "78",
+            "types": [
+               "Normal",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "148"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/660.png",
+            "back": "sprites/back/660.png"
+         },
+         "shiny": {
+            "front": "sprites/s660.png",
+            "back": "sprites/back/s660.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Fletchling"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Slow",
+            "hp": "45",
+            "attack": "50",
+            "defense": "43",
+            "sp atk": "40",
+            "sp def": "38",
+            "speed": "62",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "56"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/661.png",
+            "back": "sprites/back/661.png"
+         },
+         "shiny": {
+            "front": "sprites/s661.png",
+            "back": "sprites/back/s661.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Fletchinder"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Slow",
+            "hp": "62",
+            "attack": "73",
+            "defense": "55",
+            "sp atk": "56",
+            "sp def": "52",
+            "speed": "84",
+            "types": [
+               "Fire",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "134"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/662.png",
+            "back": "sprites/back/662.png"
+         },
+         "shiny": {
+            "front": "sprites/s662.png",
+            "back": "sprites/back/s662.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Talonflame"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "78",
+            "attack": "81",
+            "defense": "71",
+            "sp atk": "74",
+            "sp def": "69",
+            "speed": "126",
+            "types": [
+               "Fire",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/663.png",
+            "back": "sprites/back/663.png"
+         },
+         "shiny": {
+            "front": "sprites/s663.png",
+            "back": "sprites/back/s663.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Scatterbug"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Medium Fast",
+            "hp": "38",
+            "attack": "35",
+            "defense": "40",
+            "sp atk": "27",
+            "sp def": "25",
+            "speed": "35",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "40"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/664.png",
+            "back": "sprites/back/664.png"
+         },
+         "shiny": {
+            "front": "sprites/s664.png",
+            "back": "sprites/back/s664.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Spewpa"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "22",
+            "defense": "60",
+            "sp atk": "27",
+            "sp def": "30",
+            "speed": "29",
+            "types": [
+               "Bug"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "75"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/665.png",
+            "back": "sprites/back/665.png"
+         },
+         "shiny": {
+            "front": "sprites/s665.png",
+            "back": "sprites/back/s665.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Vivillon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "80",
+            "attack": "52",
+            "defense": "50",
+            "sp atk": "90",
+            "sp def": "50",
+            "speed": "89",
+            "types": [
+               "Bug",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "185"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/666.png",
+            "back": "sprites/back/666.png"
+         },
+         "shiny": {
+            "front": "sprites/s666.png",
+            "back": "sprites/back/s666.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Litleo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "220",
+            "growth rate": "Medium Slow",
+            "hp": "62",
+            "attack": "50",
+            "defense": "58",
+            "sp atk": "73",
+            "sp def": "54",
+            "speed": "72",
+            "types": [
+               "Fire",
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "74"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/667.png",
+            "back": "sprites/back/667.png"
+         },
+         "shiny": {
+            "front": "sprites/s667.png",
+            "back": "sprites/back/s667.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pyroar"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "65",
+            "growth rate": "Medium Slow",
+            "hp": "86",
+            "attack": "68",
+            "defense": "72",
+            "sp atk": "109",
+            "sp def": "66",
+            "speed": "106",
+            "types": [
+               "Fire",
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "177"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/668.png",
+            "back": "sprites/back/668.png"
+         },
+         "shiny": {
+            "front": "sprites/s668.png",
+            "back": "sprites/back/s668.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Flabebe"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "225",
+            "growth rate": "Medium Fast",
+            "hp": "44",
+            "attack": "38",
+            "defense": "39",
+            "sp atk": "61",
+            "sp def": "79",
+            "speed": "42",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/669.png",
+            "back": "sprites/back/669.png"
+         },
+         "shiny": {
+            "front": "sprites/s669.png",
+            "back": "sprites/back/s669.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Floette"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "54",
+            "attack": "45",
+            "defense": "47",
+            "sp atk": "75",
+            "sp def": "98",
+            "speed": "52",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "130"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/670.png",
+            "back": "sprites/back/670.png"
+         },
+         "shiny": {
+            "front": "sprites/s670.png",
+            "back": "sprites/back/s670.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Florges"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "78",
+            "attack": "65",
+            "defense": "68",
+            "sp atk": "112",
+            "sp def": "154",
+            "speed": "75",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "248"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/671.png",
+            "back": "sprites/back/671.png"
+         },
+         "shiny": {
+            "front": "sprites/s671.png",
+            "back": "sprites/back/s671.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Skiddo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Fast",
+            "hp": "66",
+            "attack": "65",
+            "defense": "48",
+            "sp atk": "62",
+            "sp def": "57",
+            "speed": "52",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "70"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/672.png",
+            "back": "sprites/back/672.png"
+         },
+         "shiny": {
+            "front": "sprites/s672.png",
+            "back": "sprites/back/s672.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gogoat"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "123",
+            "attack": "100",
+            "defense": "62",
+            "sp atk": "97",
+            "sp def": "81",
+            "speed": "68",
+            "types": [
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "186"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/673.png",
+            "back": "sprites/back/673.png"
+         },
+         "shiny": {
+            "front": "sprites/s673.png",
+            "back": "sprites/back/s673.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pancham"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "220",
+            "growth rate": "Medium Fast",
+            "hp": "67",
+            "attack": "82",
+            "defense": "62",
+            "sp atk": "46",
+            "sp def": "48",
+            "speed": "43",
+            "types": [
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "70"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/674.png",
+            "back": "sprites/back/674.png"
+         },
+         "shiny": {
+            "front": "sprites/s674.png",
+            "back": "sprites/back/s674.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pangoro"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "65",
+            "growth rate": "Medium Fast",
+            "hp": "95",
+            "attack": "124",
+            "defense": "78",
+            "sp atk": "69",
+            "sp def": "71",
+            "speed": "58",
+            "types": [
+               "Fighting",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/675.png",
+            "back": "sprites/back/675.png"
+         },
+         "shiny": {
+            "front": "sprites/s675.png",
+            "back": "sprites/back/s675.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Furfrou"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "160",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "80",
+            "defense": "60",
+            "sp atk": "65",
+            "sp def": "90",
+            "speed": "102",
+            "types": [
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "165"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/676.png",
+            "back": "sprites/back/676.png"
+         },
+         "shiny": {
+            "front": "sprites/s676.png",
+            "back": "sprites/back/s676.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Espurr"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "62",
+            "attack": "48",
+            "defense": "54",
+            "sp atk": "63",
+            "sp def": "60",
+            "speed": "68",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "71"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/677.png",
+            "back": "sprites/back/677.png"
+         },
+         "shiny": {
+            "front": "sprites/s677.png",
+            "back": "sprites/back/s677.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Meowstic-male"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "74",
+            "attack": "48",
+            "defense": "76",
+            "sp atk": "83",
+            "sp def": "81",
+            "speed": "104",
+            "types": [
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "163"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/678.png",
+            "back": "sprites/back/678.png"
+         },
+         "shiny": {
+            "front": "sprites/s678.png",
+            "back": "sprites/back/s678.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Honedge"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "180",
+            "growth rate": "Medium Fast",
+            "hp": "45",
+            "attack": "80",
+            "defense": "100",
+            "sp atk": "35",
+            "sp def": "37",
+            "speed": "28",
+            "types": [
+               "Steel",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "65"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/679.png",
+            "back": "sprites/back/679.png"
+         },
+         "shiny": {
+            "front": "sprites/s679.png",
+            "back": "sprites/back/s679.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Doublade"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "59",
+            "attack": "110",
+            "defense": "150",
+            "sp atk": "45",
+            "sp def": "49",
+            "speed": "35",
+            "types": [
+               "Steel",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "157"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/680.png",
+            "back": "sprites/back/680.png"
+         },
+         "shiny": {
+            "front": "sprites/s680.png",
+            "back": "sprites/back/s680.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Aegislash-shield"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "50",
+            "defense": "150",
+            "sp atk": "50",
+            "sp def": "150",
+            "speed": "60",
+            "types": [
+               "Steel",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "234"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/681.png",
+            "back": "sprites/back/681.png"
+         },
+         "shiny": {
+            "front": "sprites/s681.png",
+            "back": "sprites/back/s681.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Spritzee"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Fast",
+            "hp": "78",
+            "attack": "52",
+            "defense": "60",
+            "sp atk": "63",
+            "sp def": "65",
+            "speed": "23",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "68"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/682.png",
+            "back": "sprites/back/682.png"
+         },
+         "shiny": {
+            "front": "sprites/s682.png",
+            "back": "sprites/back/s682.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Aromatisse"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "140",
+            "growth rate": "Medium Fast",
+            "hp": "101",
+            "attack": "72",
+            "defense": "72",
+            "sp atk": "99",
+            "sp def": "89",
+            "speed": "29",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "162"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/683.png",
+            "back": "sprites/back/683.png"
+         },
+         "shiny": {
+            "front": "sprites/s683.png",
+            "back": "sprites/back/s683.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Swirlix"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "200",
+            "growth rate": "Medium Fast",
+            "hp": "62",
+            "attack": "48",
+            "defense": "66",
+            "sp atk": "59",
+            "sp def": "57",
+            "speed": "49",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "68"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/684.png",
+            "back": "sprites/back/684.png"
+         },
+         "shiny": {
+            "front": "sprites/s684.png",
+            "back": "sprites/back/s684.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Slurpuff"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "140",
+            "growth rate": "Medium Fast",
+            "hp": "82",
+            "attack": "80",
+            "defense": "86",
+            "sp atk": "85",
+            "sp def": "75",
+            "speed": "72",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/685.png",
+            "back": "sprites/back/685.png"
+         },
+         "shiny": {
+            "front": "sprites/s685.png",
+            "back": "sprites/back/s685.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Inkay"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "53",
+            "attack": "54",
+            "defense": "53",
+            "sp atk": "37",
+            "sp def": "46",
+            "speed": "45",
+            "types": [
+               "Dark",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/686.png",
+            "back": "sprites/back/686.png"
+         },
+         "shiny": {
+            "front": "sprites/s686.png",
+            "back": "sprites/back/s686.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Malamar"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "80",
+            "growth rate": "Medium Fast",
+            "hp": "86",
+            "attack": "92",
+            "defense": "88",
+            "sp atk": "68",
+            "sp def": "75",
+            "speed": "73",
+            "types": [
+               "Dark",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "169"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/687.png",
+            "back": "sprites/back/687.png"
+         },
+         "shiny": {
+            "front": "sprites/s687.png",
+            "back": "sprites/back/s687.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Binacle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "42",
+            "attack": "52",
+            "defense": "67",
+            "sp atk": "39",
+            "sp def": "56",
+            "speed": "50",
+            "types": [
+               "Rock",
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/688.png",
+            "back": "sprites/back/688.png"
+         },
+         "shiny": {
+            "front": "sprites/s688.png",
+            "back": "sprites/back/s688.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Barbaracle"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "72",
+            "attack": "105",
+            "defense": "115",
+            "sp atk": "54",
+            "sp def": "86",
+            "speed": "68",
+            "types": [
+               "Rock",
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/689.png",
+            "back": "sprites/back/689.png"
+         },
+         "shiny": {
+            "front": "sprites/s689.png",
+            "back": "sprites/back/s689.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Skrelp"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "225",
+            "growth rate": "Medium Fast",
+            "hp": "50",
+            "attack": "60",
+            "defense": "60",
+            "sp atk": "60",
+            "sp def": "60",
+            "speed": "30",
+            "types": [
+               "Poison",
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "64"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/690.png",
+            "back": "sprites/back/690.png"
+         },
+         "shiny": {
+            "front": "sprites/s690.png",
+            "back": "sprites/back/s690.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Dragalge"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "55",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "75",
+            "defense": "90",
+            "sp atk": "97",
+            "sp def": "123",
+            "speed": "44",
+            "types": [
+               "Poison",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/691.png",
+            "back": "sprites/back/691.png"
+         },
+         "shiny": {
+            "front": "sprites/s691.png",
+            "back": "sprites/back/s691.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Clauncher"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "225",
+            "growth rate": "Slow",
+            "hp": "50",
+            "attack": "53",
+            "defense": "62",
+            "sp atk": "58",
+            "sp def": "63",
+            "speed": "44",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "66"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/692.png",
+            "back": "sprites/back/692.png"
+         },
+         "shiny": {
+            "front": "sprites/s692.png",
+            "back": "sprites/back/s692.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Clawitzer"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "55",
+            "growth rate": "Slow",
+            "hp": "71",
+            "attack": "73",
+            "defense": "88",
+            "sp atk": "120",
+            "sp def": "89",
+            "speed": "59",
+            "types": [
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "100"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/693.png",
+            "back": "sprites/back/693.png"
+         },
+         "shiny": {
+            "front": "sprites/s693.png",
+            "back": "sprites/back/s693.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Helioptile"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "44",
+            "attack": "38",
+            "defense": "33",
+            "sp atk": "61",
+            "sp def": "43",
+            "speed": "70",
+            "types": [
+               "Electric",
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "58"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/694.png",
+            "back": "sprites/back/694.png"
+         },
+         "shiny": {
+            "front": "sprites/s694.png",
+            "back": "sprites/back/s694.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Heliolisk"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "62",
+            "attack": "55",
+            "defense": "52",
+            "sp atk": "109",
+            "sp def": "94",
+            "speed": "109",
+            "types": [
+               "Electric",
+               "Normal"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/695.png",
+            "back": "sprites/back/695.png"
+         },
+         "shiny": {
+            "front": "sprites/s695.png",
+            "back": "sprites/back/s695.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tyrunt"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "58",
+            "attack": "89",
+            "defense": "77",
+            "sp atk": "45",
+            "sp def": "45",
+            "speed": "48",
+            "types": [
+               "Rock",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "72"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/696.png",
+            "back": "sprites/back/696.png"
+         },
+         "shiny": {
+            "front": "sprites/s696.png",
+            "back": "sprites/back/s696.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Tyrantrum"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "82",
+            "attack": "121",
+            "defense": "119",
+            "sp atk": "69",
+            "sp def": "59",
+            "speed": "71",
+            "types": [
+               "Rock",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "182"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/697.png",
+            "back": "sprites/back/697.png"
+         },
+         "shiny": {
+            "front": "sprites/s697.png",
+            "back": "sprites/back/s697.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Amaura"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "77",
+            "attack": "59",
+            "defense": "50",
+            "sp atk": "67",
+            "sp def": "63",
+            "speed": "46",
+            "types": [
+               "Rock",
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "72"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/698.png",
+            "back": "sprites/back/698.png"
+         },
+         "shiny": {
+            "front": "sprites/s698.png",
+            "back": "sprites/back/s698.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Aurorus"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "123",
+            "attack": "77",
+            "defense": "72",
+            "sp atk": "99",
+            "sp def": "92",
+            "speed": "58",
+            "types": [
+               "Rock",
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "104"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/699.png",
+            "back": "sprites/back/699.png"
+         },
+         "shiny": {
+            "front": "sprites/s699.png",
+            "back": "sprites/back/s699.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sylveon"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "95",
+            "attack": "65",
+            "defense": "65",
+            "sp atk": "110",
+            "sp def": "130",
+            "speed": "60",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "184"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/700.png",
+            "back": "sprites/back/700.png"
+         },
+         "shiny": {
+            "front": "sprites/s700.png",
+            "back": "sprites/back/s700.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Hawlucha"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "100",
+            "growth rate": "Medium Fast",
+            "hp": "78",
+            "attack": "92",
+            "defense": "75",
+            "sp atk": "74",
+            "sp def": "63",
+            "speed": "118",
+            "types": [
+               "Fighting",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "175"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/701.png",
+            "back": "sprites/back/701.png"
+         },
+         "shiny": {
+            "front": "sprites/s701.png",
+            "back": "sprites/back/s701.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Dedenne"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "180",
+            "growth rate": "Medium Fast",
+            "hp": "67",
+            "attack": "58",
+            "defense": "57",
+            "sp atk": "81",
+            "sp def": "67",
+            "speed": "101",
+            "types": [
+               "Electric",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "151"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/702.png",
+            "back": "sprites/back/702.png"
+         },
+         "shiny": {
+            "front": "sprites/s702.png",
+            "back": "sprites/back/s702.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Carbink"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow",
+            "hp": "50",
+            "attack": "50",
+            "defense": "150",
+            "sp atk": "50",
+            "sp def": "150",
+            "speed": "50",
+            "types": [
+               "Rock",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "100"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/703.png",
+            "back": "sprites/back/703.png"
+         },
+         "shiny": {
+            "front": "sprites/s703.png",
+            "back": "sprites/back/s703.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Goomy"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "45",
+            "attack": "50",
+            "defense": "35",
+            "sp atk": "55",
+            "sp def": "75",
+            "speed": "40",
+            "types": [
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "60"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/704.png",
+            "back": "sprites/back/704.png"
+         },
+         "shiny": {
+            "front": "sprites/s704.png",
+            "back": "sprites/back/s704.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Sliggoo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "68",
+            "attack": "75",
+            "defense": "53",
+            "sp atk": "83",
+            "sp def": "113",
+            "speed": "60",
+            "types": [
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "158"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/705.png",
+            "back": "sprites/back/705.png"
+         },
+         "shiny": {
+            "front": "sprites/s705.png",
+            "back": "sprites/back/s705.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Goodra"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "90",
+            "attack": "100",
+            "defense": "70",
+            "sp atk": "110",
+            "sp def": "150",
+            "speed": "80",
+            "types": [
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/706.png",
+            "back": "sprites/back/706.png"
+         },
+         "shiny": {
+            "front": "sprites/s706.png",
+            "back": "sprites/back/s706.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Klefki"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Fast",
+            "hp": "57",
+            "attack": "80",
+            "defense": "91",
+            "sp atk": "80",
+            "sp def": "87",
+            "speed": "75",
+            "types": [
+               "Steel",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "165"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/707.png",
+            "back": "sprites/back/707.png"
+         },
+         "shiny": {
+            "front": "sprites/s707.png",
+            "back": "sprites/back/s707.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Phantump"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "43",
+            "attack": "70",
+            "defense": "48",
+            "sp atk": "50",
+            "sp def": "60",
+            "speed": "38",
+            "types": [
+               "Ghost",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "62"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/708.png",
+            "back": "sprites/back/708.png"
+         },
+         "shiny": {
+            "front": "sprites/s708.png",
+            "back": "sprites/back/s708.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Trevenant"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "85",
+            "attack": "110",
+            "defense": "76",
+            "sp atk": "65",
+            "sp def": "82",
+            "speed": "56",
+            "types": [
+               "Ghost",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "166"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/709.png",
+            "back": "sprites/back/709.png"
+         },
+         "shiny": {
+            "front": "sprites/s709.png",
+            "back": "sprites/back/s709.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Pumpkaboo-average"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "120",
+            "growth rate": "Medium Fast",
+            "hp": "49",
+            "attack": "66",
+            "defense": "70",
+            "sp atk": "44",
+            "sp def": "55",
+            "speed": "51",
+            "types": [
+               "Ghost",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "67"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/710.png",
+            "back": "sprites/back/710.png"
+         },
+         "shiny": {
+            "front": "sprites/s710.png",
+            "back": "sprites/back/s710.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Gourgeist-average"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "90",
+            "defense": "122",
+            "sp atk": "58",
+            "sp def": "75",
+            "speed": "84",
+            "types": [
+               "Ghost",
+               "Grass"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "173"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/711.png",
+            "back": "sprites/back/711.png"
+         },
+         "shiny": {
+            "front": "sprites/s711.png",
+            "back": "sprites/back/s711.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Bergmite"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "55",
+            "attack": "69",
+            "defense": "85",
+            "sp atk": "32",
+            "sp def": "35",
+            "speed": "28",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "61"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/712.png",
+            "back": "sprites/back/712.png"
+         },
+         "shiny": {
+            "front": "sprites/s712.png",
+            "back": "sprites/back/s712.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Avalugg"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "55",
+            "growth rate": "Medium Fast",
+            "hp": "95",
+            "attack": "117",
+            "defense": "184",
+            "sp atk": "44",
+            "sp def": "46",
+            "speed": "28",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "180"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/713.png",
+            "back": "sprites/back/713.png"
+         },
+         "shiny": {
+            "front": "sprites/s713.png",
+            "back": "sprites/back/s713.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Noibat"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "190",
+            "growth rate": "Medium Fast",
+            "hp": "40",
+            "attack": "30",
+            "defense": "35",
+            "sp atk": "45",
+            "sp def": "40",
+            "speed": "55",
+            "types": [
+               "Flying",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "49"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/714.png",
+            "back": "sprites/back/714.png"
+         },
+         "shiny": {
+            "front": "sprites/s714.png",
+            "back": "sprites/back/s714.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Noivern"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "85",
+            "attack": "70",
+            "defense": "80",
+            "sp atk": "97",
+            "sp def": "80",
+            "speed": "123",
+            "types": [
+               "Flying",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "187"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/715.png",
+            "back": "sprites/back/715.png"
+         },
+         "shiny": {
+            "front": "sprites/s715.png",
+            "back": "sprites/back/s715.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Xerneas"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "126",
+            "attack": "131",
+            "defense": "95",
+            "sp atk": "131",
+            "sp def": "98",
+            "speed": "99",
+            "types": [
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "306"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/716.png",
+            "back": "sprites/back/716.png"
+         },
+         "shiny": {
+            "front": "sprites/s716.png",
+            "back": "sprites/back/s716.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Yveltal"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "126",
+            "attack": "131",
+            "defense": "95",
+            "sp atk": "131",
+            "sp def": "98",
+            "speed": "99",
+            "types": [
+               "Dark",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "306"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/717.png",
+            "back": "sprites/back/717.png"
+         },
+         "shiny": {
+            "front": "sprites/s717.png",
+            "back": "sprites/back/s717.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Zygarde"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "108",
+            "attack": "100",
+            "defense": "121",
+            "sp atk": "81",
+            "sp def": "95",
+            "speed": "95",
+            "types": [
+               "Dragon",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/718.png",
+            "back": "sprites/back/718.png"
+         },
+         "shiny": {
+            "front": "sprites/s718.png",
+            "back": "sprites/back/s718.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Diancie"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "50",
+            "attack": "100",
+            "defense": "150",
+            "sp atk": "100",
+            "sp def": "150",
+            "speed": "50",
+            "types": [
+               "Rock",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/719.png",
+            "back": "sprites/back/719.png"
+         },
+         "shiny": {
+            "front": "sprites/s719.png",
+            "back": "sprites/back/s719.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Hoopa"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "110",
+            "defense": "60",
+            "sp atk": "150",
+            "sp def": "130",
+            "speed": "70",
+            "types": [
+               "Psychic",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/720.png",
+            "back": "sprites/back/720.png"
+         },
+         "shiny": {
+            "front": "sprites/s720.png",
+            "back": "sprites/back/s720.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "Volcanion"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "110",
+            "defense": "120",
+            "sp atk": "130",
+            "sp def": "90",
+            "speed": "70",
+            "types": [
+               "Fire",
+               "Water"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "270"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/721.png",
+            "back": "sprites/back/721.png"
+         },
+         "shiny": {
+            "front": "sprites/s721.png",
+            "back": "sprites/back/s721.png"
+         }
+      }
+   },
    {
       "pokemon": [
          {
@@ -4842,27 +27035,33 @@ const POKEDEX = [
       "stats": [
          {
             "catch rate": "45",
-			"growth rate": "Medium Slow",
+            "growth rate": "Medium Slow",
             "hp": "80",
             "attack": "100",
             "defense": "123",
             "sp atk": "122",
             "sp def": "120",
             "speed": "80",
-            "types": {
-               "text": "Grass",
-               "href": "https://pokemondb.net/type/grass"
-            }
+            "types": [
+               "Grass",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "208"
+            "base exp": "281"
          }
       ],
       "images": {
-         "front": "/sprites/003m.png",
-         "back": "/sprites/back/003m.png"
+         "normal": {
+            "front": "sprites/003m.png",
+            "back": "sprites/back/003m.png"
+         },
+         "shiny": {
+            "front": "sprites/s003m.png",
+            "back": "sprites/back/s003m.png"
+         }
       }
    },
    {
@@ -4881,20 +27080,26 @@ const POKEDEX = [
             "sp atk": "130",
             "sp def": "85",
             "speed": "100",
-            "types": {
-               "text": "Dragon",
-               "href": "https://pokemondb.net/type/dragon"
-            }
+            "types": [
+               "Fire",
+               "Dragon"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "209"
+            "base exp": "285"
          }
       ],
       "images": {
-         "front": "/sprites/006mx.png",
-         "back": "/sprites/back/006mx.png"
+         "normal": {
+            "front": "sprites/006mx.png",
+            "back": "sprites/back/006mx.png"
+         },
+         "shiny": {
+            "front": "sprites/s006mx.png",
+            "back": "sprites/back/s006mx.png"
+         }
       }
    },
    {
@@ -4913,20 +27118,26 @@ const POKEDEX = [
             "sp atk": "159",
             "sp def": "115",
             "speed": "100",
-            "types": {
-               "text": "Fire",
-               "href": "https://pokemondb.net/type/fire"
-            }
+            "types": [
+               "Fire",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "209"
+            "base exp": "285"
          }
       ],
       "images": {
-         "front": "/sprites/006my.png",
-         "back": "/sprites/back/006my.png"
+         "normal": {
+            "front": "sprites/006my.png",
+            "back": "sprites/back/006my.png"
+         },
+         "shiny": {
+            "front": "sprites/s006my.png",
+            "back": "sprites/back/s006my.png"
+         }
       }
    },
    {
@@ -4945,86 +27156,27 @@ const POKEDEX = [
             "sp atk": "135",
             "sp def": "115",
             "speed": "78",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "210"
+            "base exp": "284"
          }
       ],
       "images": {
-         "front": "/sprites/009m.png",
-         "back": "/sprites/back/009m.png"
+         "normal": {
+            "front": "sprites/009m.png",
+            "back": "sprites/back/009m.png"
+         },
+         "shiny": {
+            "front": "sprites/s009m.png",
+            "back": "sprites/back/s009m.png"
+         }
       }
    },
-   {
-      "pokemon": [
-         {
-            "Pokemon": "M-Beedrill"
-         }
-      ],
-      "stats": [
-         {
-            "catch rate": "45",
-            "growth rate": "Medium Fast",
-            "hp": "65",
-            "attack": "150",
-            "defense": "40",
-            "sp atk": "15",
-            "sp def": "80",
-            "speed": "145",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
-         }
-      ],
-      "exp": [
-         {
-            "base exp": "159"
-         }
-      ],
-      "images": {
-         "front": "/sprites/015m.png",
-         "back": "/sprites/back/015m.png"
-      }
-   },
-   {
-      "pokemon": [
-         {
-            "Pokemon": "M-Pidgeot"
-         }
-      ],
-      "stats": [
-         {
-            "catch rate": "45",
-            "growth rate": "Medium Slow",
-            "hp": "83",
-            "attack": "80",
-            "defense": "80",
-            "sp atk": "135",
-            "sp def": "80",
-            "speed": "121",
-            "types": {
-               "text": "Flying",
-               "href": "https://pokemondb.net/type/flying"
-            }
-         }
-      ],
-      "exp": [
-         {
-            "base exp": "172"
-         }
-      ],
-      "images": {
-         "front": "/sprites/018m.png",
-         "back": "/sprites/back/018m.png"
-      }
-   },   
    {
       "pokemon": [
          {
@@ -5039,56 +27191,29 @@ const POKEDEX = [
             "attack": "50",
             "defense": "65",
             "sp atk": "175",
-            "sp def": "105",
+            "sp def": "95",
             "speed": "150",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "186"
+            "base exp": "266"
          }
       ],
       "images": {
-         "front": "/sprites/065m.png",
-         "back": "/sprites/back/065m.png"
+         "normal": {
+            "front": "sprites/065m.png",
+            "back": "sprites/back/065m.png"
+         },
+         "shiny": {
+            "front": "sprites/s065m.png",
+            "back": "sprites/back/s065m.png"
+         }
       }
-   },   
-   {
-      "pokemon": [
-         {
-            "Pokemon": "M-Slowbro"
-         }
-      ],
-      "stats": [
-         {
-            "catch rate": "75",
-            "growth rate": "Medium Fast",
-            "hp": "95",
-            "attack": "75",
-            "defense": "180",
-            "sp atk": "130",
-            "sp def": "80",
-            "speed": "30",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
-         }
-      ],
-      "exp": [
-         {
-            "base exp": "164"
-         }
-      ],
-      "images": {
-         "front": "/sprites/080m.png",
-         "back": "/sprites/back/080m.png"
-      }
-   },   
+   },
    {
       "pokemon": [
          {
@@ -5105,22 +27230,28 @@ const POKEDEX = [
             "sp atk": "170",
             "sp def": "95",
             "speed": "130",
-            "types": {
-               "text": "Ghost",
-               "href": "https://pokemondb.net/type/ghost"
-            }
+            "types": [
+               "Ghost",
+               "Poison"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "190"
+            "base exp": "270"
          }
       ],
       "images": {
-         "front": "/sprites/094m.png",
-         "back": "/sprites/back/094m.png"
+         "normal": {
+            "front": "sprites/094m.png",
+            "back": "sprites/back/094m.png"
+         },
+         "shiny": {
+            "front": "sprites/s094m.png",
+            "back": "sprites/back/s094m.png"
+         }
       }
-   },   
+   },
    {
       "pokemon": [
          {
@@ -5137,22 +27268,27 @@ const POKEDEX = [
             "sp atk": "60",
             "sp def": "100",
             "speed": "100",
-            "types": {
-               "text": "Normal",
-               "href": "https://pokemondb.net/type/normal"
-            }
+            "types": [
+               "Normal"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "175"
+            "base exp": "207"
          }
       ],
       "images": {
-         "front": "/sprites/115m.png",
-         "back": "/sprites/back/115m.png"
+         "normal": {
+            "front": "sprites/115m.png",
+            "back": "sprites/back/115m.png"
+         },
+         "shiny": {
+            "front": "sprites/s115m.png",
+            "back": "sprites/back/s115m.png"
+         }
       }
-   },   
+   },
    {
       "pokemon": [
          {
@@ -5169,20 +27305,26 @@ const POKEDEX = [
             "sp atk": "65",
             "sp def": "90",
             "speed": "105",
-            "types": {
-               "text": "Bug",
-               "href": "https://pokemondb.net/type/bug"
-            }
+            "types": [
+               "Bug",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "200"
+            "base exp": "210"
          }
       ],
       "images": {
-         "front": "/sprites/127m.png",
-         "back": "/sprites/back/127m.png"
+         "normal": {
+            "front": "sprites/127m.png",
+            "back": "sprites/back/127m.png"
+         },
+         "shiny": {
+            "front": "sprites/s127m.png",
+            "back": "sprites/back/s127m.png"
+         }
       }
    },
    {
@@ -5201,20 +27343,26 @@ const POKEDEX = [
             "sp atk": "70",
             "sp def": "130",
             "speed": "81",
-            "types": {
-               "text": "Water",
-               "href": "https://pokemondb.net/type/water"
-            }
+            "types": [
+               "Water",
+               "Dark"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "214"
+            "base exp": "224"
          }
       ],
       "images": {
-         "front": "/sprites/130m.png",
-         "back": "/sprites/back/130m.png"
+         "normal": {
+            "front": "sprites/130m.png",
+            "back": "sprites/back/130m.png"
+         },
+         "shiny": {
+            "front": "sprites/s130m.png",
+            "back": "sprites/back/s130m.png"
+         }
       }
    },
    {
@@ -5233,20 +27381,26 @@ const POKEDEX = [
             "sp atk": "70",
             "sp def": "95",
             "speed": "150",
-            "types": {
-               "text": "Rock",
-               "href": "https://pokemondb.net/type/rock"
-            }
+            "types": [
+               "Rock",
+               "Flying"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "202"
+            "base exp": "215"
          }
       ],
       "images": {
-         "front": "/sprites/142m.png",
-         "back": "/sprites/back/142m.png"
+         "normal": {
+            "front": "sprites/142m.png",
+            "back": "sprites/back/142m.png"
+         },
+         "shiny": {
+            "front": "sprites/s142m.png",
+            "back": "sprites/back/s142m.png"
+         }
       }
    },
    {
@@ -5265,20 +27419,26 @@ const POKEDEX = [
             "sp atk": "154",
             "sp def": "100",
             "speed": "130",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic",
+               "Fighting"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "220"
+            "base exp": "351"
          }
       ],
       "images": {
-         "front": "/sprites/150mx.png",
-         "back": "/sprites/back/150mx.png"
+         "normal": {
+            "front": "sprites/150mx.png",
+            "back": "sprites/back/150mx.png"
+         },
+         "shiny": {
+            "front": "sprites/s150mx.png",
+            "back": "sprites/back/s150mx.png"
+         }
       }
    },
    {
@@ -5297,20 +27457,1388 @@ const POKEDEX = [
             "sp atk": "194",
             "sp def": "120",
             "speed": "140",
-            "types": {
-               "text": "Psychic",
-               "href": "https://pokemondb.net/type/psychic"
-            }
+            "types": [
+               "Psychic"
+            ]
          }
       ],
       "exp": [
          {
-            "base exp": "220"
+            "base exp": "351"
          }
       ],
       "images": {
-         "front": "/sprites/150my.png",
-         "back": "/sprites/back/150my.png"
+         "normal": {
+            "front": "sprites/150my.png",
+            "back": "sprites/back/150my.png"
+         },
+         "shiny": {
+            "front": "sprites/s150my.png",
+            "back": "sprites/back/s150my.png"
+         }
       }
-   }   
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Ampharos"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "90",
+            "attack": "95",
+            "defense": "105",
+            "sp atk": "165",
+            "sp def": "110",
+            "speed": "45",
+            "types": [
+               "Electric",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "275"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/181m.png",
+            "back": "sprites/back/181m.png"
+         },
+         "shiny": {
+            "front": "sprites/s181m.png",
+            "back": "sprites/back/s181m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Scizor"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "25",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "150",
+            "defense": "140",
+            "sp atk": "65",
+            "sp def": "100",
+            "speed": "75",
+            "types": [
+               "Bug",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "210"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/212m.png",
+            "back": "sprites/back/212m.png"
+         },
+         "shiny": {
+            "front": "sprites/s212m.png",
+            "back": "sprites/back/s212m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Heracross"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "185",
+            "defense": "115",
+            "sp atk": "40",
+            "sp def": "105",
+            "speed": "75",
+            "types": [
+               "Bug",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "210"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/214m.png",
+            "back": "sprites/back/214m.png"
+         },
+         "shiny": {
+            "front": "sprites/s214m.png",
+            "back": "sprites/back/s214m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Houndoom"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "75",
+            "attack": "90",
+            "defense": "90",
+            "sp atk": "140",
+            "sp def": "90",
+            "speed": "115",
+            "types": [
+               "Dark",
+               "Fire"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "210"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/229m.png",
+            "back": "sprites/back/229m.png"
+         },
+         "shiny": {
+            "front": "sprites/s229m.png",
+            "back": "sprites/back/s229m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Tyranitar"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "100",
+            "attack": "164",
+            "defense": "150",
+            "sp atk": "95",
+            "sp def": "120",
+            "speed": "71",
+            "types": [
+               "Rock",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "315"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/248m.png",
+            "back": "sprites/back/248m.png"
+         },
+         "shiny": {
+            "front": "sprites/s248m.png",
+            "back": "sprites/back/s248m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Blaziken"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "80",
+            "attack": "160",
+            "defense": "80",
+            "sp atk": "130",
+            "sp def": "80",
+            "speed": "100",
+            "types": [
+               "Fire",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "284"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/257m.png",
+            "back": "sprites/back/257m.png"
+         },
+         "shiny": {
+            "front": "sprites/s257m.png",
+            "back": "sprites/back/s257m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Gardevoir"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "68",
+            "attack": "85",
+            "defense": "65",
+            "sp atk": "165",
+            "sp def": "135",
+            "speed": "100",
+            "types": [
+               "Psychic",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "278"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/282m.png",
+            "back": "sprites/back/282m.png"
+         },
+         "shiny": {
+            "front": "sprites/s282m.png",
+            "back": "sprites/back/s282m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Mawile"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "50",
+            "attack": "105",
+            "defense": "125",
+            "sp atk": "55",
+            "sp def": "95",
+            "speed": "50",
+            "types": [
+               "Steel",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/303m.png",
+            "back": "sprites/back/303m.png"
+         },
+         "shiny": {
+            "front": "sprites/s303m.png",
+            "back": "sprites/back/s303m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Aggron"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "140",
+            "defense": "230",
+            "sp atk": "60",
+            "sp def": "80",
+            "speed": "50",
+            "types": [
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "284"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/306m.png",
+            "back": "sprites/back/306m.png"
+         },
+         "shiny": {
+            "front": "sprites/s306m.png",
+            "back": "sprites/back/s306m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Medicham"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "90",
+            "growth rate": "Medium Fast",
+            "hp": "60",
+            "attack": "100",
+            "defense": "85",
+            "sp atk": "80",
+            "sp def": "85",
+            "speed": "100",
+            "types": [
+               "Fighting",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "179"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/308m.png",
+            "back": "sprites/back/308m.png"
+         },
+         "shiny": {
+            "front": "sprites/s308m.png",
+            "back": "sprites/back/s308m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Manectric"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "75",
+            "defense": "80",
+            "sp atk": "135",
+            "sp def": "80",
+            "speed": "135",
+            "types": [
+               "Electric"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "201"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/310m.png",
+            "back": "sprites/back/310m.png"
+         },
+         "shiny": {
+            "front": "sprites/s310m.png",
+            "back": "sprites/back/s310m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Banette"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Fast",
+            "hp": "64",
+            "attack": "165",
+            "defense": "75",
+            "sp atk": "93",
+            "sp def": "83",
+            "speed": "75",
+            "types": [
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "194"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/354m.png",
+            "back": "sprites/back/354m.png"
+         },
+         "shiny": {
+            "front": "sprites/s354m.png",
+            "back": "sprites/back/s354m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Absol"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "30",
+            "growth rate": "Medium Slow",
+            "hp": "65",
+            "attack": "150",
+            "defense": "60",
+            "sp atk": "115",
+            "sp def": "60",
+            "speed": "115",
+            "types": [
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "198"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/359m.png",
+            "back": "sprites/back/359m.png"
+         },
+         "shiny": {
+            "front": "sprites/s359m.png",
+            "back": "sprites/back/s359m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Garchomp"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "108",
+            "attack": "170",
+            "defense": "115",
+            "sp atk": "120",
+            "sp def": "95",
+            "speed": "92",
+            "types": [
+               "Dragon",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "315"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/445m.png",
+            "back": "sprites/back/445m.png"
+         },
+         "shiny": {
+            "front": "sprites/s445m.png",
+            "back": "sprites/back/s445m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Lucario"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "145",
+            "defense": "88",
+            "sp atk": "140",
+            "sp def": "70",
+            "speed": "112",
+            "types": [
+               "Fighting",
+               "Steel"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "219"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/448m.png",
+            "back": "sprites/back/448m.png"
+         },
+         "shiny": {
+            "front": "sprites/s448m.png",
+            "back": "sprites/back/s448m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Abomasnow"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow",
+            "hp": "90",
+            "attack": "132",
+            "defense": "105",
+            "sp atk": "132",
+            "sp def": "105",
+            "speed": "30",
+            "types": [
+               "Grass",
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "208"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/460m.png",
+            "back": "sprites/back/460m.png"
+         },
+         "shiny": {
+            "front": "sprites/s460m.png",
+            "back": "sprites/back/s460m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Latias"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "100",
+            "defense": "120",
+            "sp atk": "140",
+            "sp def": "150",
+            "speed": "110",
+            "types": [
+               "Dragon",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "315"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/380m.png",
+            "back": "sprites/back/380m.png"
+         },
+         "shiny": {
+            "front": "sprites/s380m.png",
+            "back": "sprites/back/s380m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Latios"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "130",
+            "defense": "100",
+            "sp atk": "160",
+            "sp def": "120",
+            "speed": "110",
+            "types": [
+               "Dragon",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "315"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/381m.png",
+            "back": "sprites/back/381m.png"
+         },
+         "shiny": {
+            "front": "sprites/s381m.png",
+            "back": "sprites/back/s381m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Swampert"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "100",
+            "attack": "150",
+            "defense": "110",
+            "sp atk": "95",
+            "sp def": "110",
+            "speed": "70",
+            "types": [
+               "Water",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "286"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/260m.png",
+            "back": "sprites/back/260m.png"
+         },
+         "shiny": {
+            "front": "sprites/s260m.png",
+            "back": "sprites/back/s260m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Sceptile"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "70",
+            "attack": "110",
+            "defense": "75",
+            "sp atk": "145",
+            "sp def": "85",
+            "speed": "145",
+            "types": [
+               "Grass",
+               "Dragon"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "284"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/254m.png",
+            "back": "sprites/back/254m.png"
+         },
+         "shiny": {
+            "front": "sprites/s254m.png",
+            "back": "sprites/back/s254m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Sableye"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "50",
+            "attack": "85",
+            "defense": "125",
+            "sp atk": "85",
+            "sp def": "115",
+            "speed": "20",
+            "types": [
+               "Dark",
+               "Ghost"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "168"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/302m.png",
+            "back": "sprites/back/302m.png"
+         },
+         "shiny": {
+            "front": "sprites/s302m.png",
+            "back": "sprites/back/s302m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Altaria"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow then very Fast",
+            "hp": "75",
+            "attack": "110",
+            "defense": "110",
+            "sp atk": "110",
+            "sp def": "105",
+            "speed": "80",
+            "types": [
+               "Dragon",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "207"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/334m.png",
+            "back": "sprites/back/334m.png"
+         },
+         "shiny": {
+            "front": "sprites/s334m.png",
+            "back": "sprites/back/s334m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Gallade"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "68",
+            "attack": "165",
+            "defense": "95",
+            "sp atk": "65",
+            "sp def": "115",
+            "speed": "110",
+            "types": [
+               "Psychic",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "278"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/475m.png",
+            "back": "sprites/back/475m.png"
+         },
+         "shiny": {
+            "front": "sprites/s475m.png",
+            "back": "sprites/back/s475m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Audino"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "255",
+            "growth rate": "Fast",
+            "hp": "103",
+            "attack": "60",
+            "defense": "126",
+            "sp atk": "80",
+            "sp def": "126",
+            "speed": "50",
+            "types": [
+               "Normal",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "425"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/531m.png",
+            "back": "sprites/back/531m.png"
+         },
+         "shiny": {
+            "front": "sprites/s531m.png",
+            "back": "sprites/back/s531m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Sharpedo"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Slow",
+            "hp": "70",
+            "attack": "140",
+            "defense": "70",
+            "sp atk": "110",
+            "sp def": "65",
+            "speed": "105",
+            "types": [
+               "Water",
+               "Dark"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "196"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/319m.png",
+            "back": "sprites/back/319m.png"
+         },
+         "shiny": {
+            "front": "sprites/s319m.png",
+            "back": "sprites/back/s319m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Slowbro"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "95",
+            "attack": "75",
+            "defense": "180",
+            "sp atk": "130",
+            "sp def": "80",
+            "speed": "30",
+            "types": [
+               "Water",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "207"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/080m.png",
+            "back": "sprites/back/080m.png"
+         },
+         "shiny": {
+            "front": "sprites/s080m.png",
+            "back": "sprites/back/s080m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Steelix"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "25",
+            "growth rate": "Medium Fast",
+            "hp": "75",
+            "attack": "125",
+            "defense": "230",
+            "sp atk": "55",
+            "sp def": "95",
+            "speed": "30",
+            "types": [
+               "Steel",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "214"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/208m.png",
+            "back": "sprites/back/208m.png"
+         },
+         "shiny": {
+            "front": "sprites/s208m.png",
+            "back": "sprites/back/s208m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Pidgeot"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Slow",
+            "hp": "83",
+            "attack": "80",
+            "defense": "80",
+            "sp atk": "135",
+            "sp def": "80",
+            "speed": "121",
+            "types": [
+               "Normal",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "261"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/018m.png",
+            "back": "sprites/back/018m.png"
+         },
+         "shiny": {
+            "front": "sprites/s018m.png",
+            "back": "sprites/back/s018m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Glalie"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "75",
+            "growth rate": "Medium Fast",
+            "hp": "80",
+            "attack": "120",
+            "defense": "80",
+            "sp atk": "120",
+            "sp def": "80",
+            "speed": "100",
+            "types": [
+               "Ice"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "203"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/362m.png",
+            "back": "sprites/back/362m.png"
+         },
+         "shiny": {
+            "front": "sprites/s362m.png",
+            "back": "sprites/back/s362m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Diancie"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "50",
+            "attack": "160",
+            "defense": "110",
+            "sp atk": "160",
+            "sp def": "110",
+            "speed": "110",
+            "types": [
+               "Rock",
+               "Fairy"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "315"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/719m.png",
+            "back": "sprites/back/719m.png"
+         },
+         "shiny": {
+            "front": "sprites/s719m.png",
+            "back": "sprites/back/s719m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Metagross"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "80",
+            "attack": "145",
+            "defense": "150",
+            "sp atk": "105",
+            "sp def": "110",
+            "speed": "110",
+            "types": [
+               "Steel",
+               "Psychic"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "315"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/376m.png",
+            "back": "sprites/back/376m.png"
+         },
+         "shiny": {
+            "front": "sprites/s376m.png",
+            "back": "sprites/back/s376m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Rayquaza"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "3",
+            "growth rate": "Slow",
+            "hp": "105",
+            "attack": "180",
+            "defense": "100",
+            "sp atk": "180",
+            "sp def": "100",
+            "speed": "115",
+            "types": [
+               "Dragon",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "351"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/384m.png",
+            "back": "sprites/back/384m.png"
+         },
+         "shiny": {
+            "front": "sprites/s384m.png",
+            "back": "sprites/back/s384m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Camerupt"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "150",
+            "growth rate": "Medium Fast",
+            "hp": "70",
+            "attack": "120",
+            "defense": "100",
+            "sp atk": "145",
+            "sp def": "105",
+            "speed": "20",
+            "types": [
+               "Fire",
+               "Ground"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "196"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/323m.png",
+            "back": "sprites/back/323m.png"
+         },
+         "shiny": {
+            "front": "sprites/s323m.png",
+            "back": "sprites/back/s323m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Lopunny"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "60",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "136",
+            "defense": "94",
+            "sp atk": "54",
+            "sp def": "96",
+            "speed": "135",
+            "types": [
+               "Normal",
+               "Fighting"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "203"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/428m.png",
+            "back": "sprites/back/428m.png"
+         },
+         "shiny": {
+            "front": "sprites/s428m.png",
+            "back": "sprites/back/s428m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Salamence"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Slow",
+            "hp": "95",
+            "attack": "145",
+            "defense": "130",
+            "sp atk": "120",
+            "sp def": "90",
+            "speed": "120",
+            "types": [
+               "Dragon",
+               "Flying"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "315"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/373m.png",
+            "back": "sprites/back/373m.png"
+         },
+         "shiny": {
+            "front": "sprites/s373m.png",
+            "back": "sprites/back/s373m.png"
+         }
+      }
+   },
+   {
+      "pokemon": [
+         {
+            "Pokemon": "M-Beedrill"
+         }
+      ],
+      "stats": [
+         {
+            "catch rate": "45",
+            "growth rate": "Medium Fast",
+            "hp": "65",
+            "attack": "150",
+            "defense": "40",
+            "sp atk": "15",
+            "sp def": "80",
+            "speed": "145",
+            "types": [
+               "Bug",
+               "Poison"
+            ]
+         }
+      ],
+      "exp": [
+         {
+            "base exp": "223"
+         }
+      ],
+      "images": {
+         "normal": {
+            "front": "sprites/015m.png",
+            "back": "sprites/back/015m.png"
+         },
+         "shiny": {
+            "front": "sprites/s015m.png",
+            "back": "sprites/back/s015m.png"
+         }
+      }
+   }
 ];

--- a/main.js
+++ b/main.js
@@ -327,11 +327,11 @@ const makePoke = (pokeModel, initialLevel, initialExp) => {
     pokeName: () => poke.pokemon[0].Pokemon
   , image: () => {
     return {
-      front: poke.images.front
-    , back: poke.images.back
+      front: poke.images.normal.front
+    , back: poke.images.normal.back
     }
   }
-  , type: () => poke.stats[0].types.text
+  , type: () => poke.stats[0].types[0]
   , catchRate: () => Number(poke.stats[0]['catch rate'])
   , lifeAsText: () => '' + (combat.mutable.hp < 0 ? 0 : combat.mutable.hp) + ' / ' + combat.maxHp()
   , life: {


### PR DESCRIPTION
The updates in main.js are needed to support the changed format. Now every pokemon has up to two types and both a normal and shiny set of sprites, paving the way for dual type damage multipliers and shiny encounters in the future :)

Find the import script at https://github.com/Fastigium/richardpaulastley.github.io/blob/pokeapi-import/pokeapi/import.php